### PR TITLE
fix: use listingStatus as primary source for listing status badge in …

### DIFF
--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -27,6 +27,7 @@ import {
   ListingFilterRequest,
   ProductType,
   ModerationStatus,
+  SummaryListingStatus,
 } from '@/api/types/listing.type'
 import { PostStatus, UIPostData } from '@/types/posts.type'
 
@@ -259,6 +260,29 @@ const deriveStatusFromVerification = (
   }
 }
 
+const deriveStatusFromListingStatus = (
+  listingStatus: SummaryListingStatus | null | undefined,
+  verificationStatus: string | null | undefined,
+  expired: boolean | null | undefined,
+): PostStatus => {
+  switch (listingStatus) {
+    case 'EXPIRED':
+      return 'expired'
+    case 'IN_REVIEW':
+    case 'RESUBMITTED':
+    case 'PENDING_PAYMENT':
+      return 'pending'
+    case 'DISPLAYING':
+    case 'EXPIRING_SOON':
+    case 'VERIFIED':
+      return 'approved'
+    case 'REJECTED':
+      return 'rejected'
+    default:
+      return deriveStatusFromVerification(verificationStatus, expired)
+  }
+}
+
 const normalizeListingType = (
   type: string | null | undefined,
 ): 'for_rent' | 'for_sale' => {
@@ -307,7 +331,8 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
     postedDate: date,
     postedTime: time,
     expiryDate,
-    status: deriveStatusFromVerification(
+    status: deriveStatusFromListingStatus(
+      item.listingStatus,
       item.adminVerification?.verificationStatus,
       item.expired,
     ),


### PR DESCRIPTION
…admin

Listing with listingStatus=EXPIRED was incorrectly shown as "Chờ duyệt" because the old logic relied on the `expired` boolean which could be false even when listingStatus is EXPIRED. Now derives display status from listingStatus directly, falling back to the old verification-based logic only when listingStatus is null.