### PR TITLE
feat: granular listing status badges and send listingStatus with mode…

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -259,7 +259,7 @@ export interface ListingFilterRequest {
   /** Matches owner firstName/lastName/contactPhoneNumber/phoneNumber (case-insensitive contains). */
   ownerSearch?: string
   moderationStatus?: ModerationStatus
-  listingStatus?: ListingStatus
+  listingStatus?: SummaryListingStatus
   verified?: boolean
   isVerify?: boolean
   expired?: boolean

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -78,13 +78,17 @@ export const PostTable: React.FC<PostTableProps> = ({
   }
 
   const getStatusLabel = (status: PostStatus): string => {
-    const labels = {
+    const labels: Record<PostStatus, string> = {
       pending: t('statuses.pending'),
+      resubmitted: t('statuses.resubmitted'),
       approved: t('statuses.approved'),
       rejected: t('statuses.rejected'),
+      revision_required: t('statuses.revision_required'),
+      suspended: t('statuses.suspended'),
       expired: t('statuses.expired'),
+      pending_payment: t('statuses.pending_payment'),
     }
-    return labels[status]
+    return labels[status] ?? t('statuses.pending')
   }
 
   const columns: Column<UIPostData>[] = [

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1721,9 +1721,13 @@
     },
     "statuses": {
       "pending": "Pending",
+      "resubmitted": "Resubmitted",
       "approved": "Approved",
       "rejected": "Rejected",
-      "expired": "Expired"
+      "revision_required": "Revision Required",
+      "suspended": "Suspended",
+      "expired": "Expired",
+      "pending_payment": "Pending Payment"
     },
     "toasts": {
       "loadListingsError": "Unable to load listings. Please try again.",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1685,9 +1685,13 @@
     },
     "statuses": {
       "pending": "Chờ Duyệt",
+      "resubmitted": "Đã Gửi Lại",
       "approved": "Đã Duyệt",
       "rejected": "Từ Chối",
-      "expired": "Hết Hạn"
+      "revision_required": "Cần Chỉnh Sửa",
+      "suspended": "Tạm Ngưng",
+      "expired": "Hết Hạn",
+      "pending_payment": "Chờ Thanh Toán"
     },
     "toasts": {
       "loadListingsError": "Không thể tải danh sách tin đăng. Vui lòng thử lại.",

--- a/src/types/posts.type.ts
+++ b/src/types/posts.type.ts
@@ -1,6 +1,14 @@
 import { Amenity } from '@/api/types/listing.type'
 
-export type PostStatus = 'pending' | 'approved' | 'rejected' | 'expired'
+export type PostStatus =
+  | 'pending'
+  | 'resubmitted'
+  | 'approved'
+  | 'rejected'
+  | 'revision_required'
+  | 'suspended'
+  | 'expired'
+  | 'pending_payment'
 
 export type UIPostData = {
   id: string

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -100,13 +100,17 @@ export const formatDateTime = (
 }
 
 export const getStatusColor = (status: PostStatus): string => {
-  const colors = {
+  const colors: Record<PostStatus, string> = {
     pending: 'border-warning/30 bg-warning/15 text-warning-foreground',
+    resubmitted: 'border-sky-500/30 bg-sky-500/10 text-sky-700',
     approved: 'border-success/30 bg-success/12 text-success-foreground',
     rejected: 'border-destructive/30 bg-destructive/10 text-destructive',
+    revision_required: 'border-orange-500/30 bg-orange-500/10 text-orange-700',
+    suspended: 'border-destructive/30 bg-destructive/10 text-destructive',
     expired: 'border-border bg-muted text-foreground/70',
+    pending_payment: 'border-purple-500/30 bg-purple-500/10 text-purple-700',
   }
-  return colors[status]
+  return colors[status] ?? colors.pending
 }
 
 export const mapUIFiltersToAPI = (
@@ -138,9 +142,25 @@ export const mapUIFiltersToAPI = (
   }
 
   // moderationStatus filter (primary moderation workflow field)
+  // Also send the corresponding listingStatus — mirrors smartrent-fe's LISTING_STATUS_MODERATION_MAP pattern
   const moderationStatus = str('moderationStatus')
   if (moderationStatus) {
     apiFilters.moderationStatus = moderationStatus as ModerationStatus
+    const moderationToListingStatus: Partial<
+      Record<ModerationStatus, SummaryListingStatus>
+    > = {
+      PENDING_REVIEW: 'IN_REVIEW',
+      RESUBMITTED: 'RESUBMITTED',
+      APPROVED: 'DISPLAYING',
+      REVISION_REQUIRED: 'REJECTED',
+      SUSPENDED: 'REJECTED',
+      REJECTED: 'REJECTED',
+    }
+    const mappedListingStatus =
+      moderationToListingStatus[moderationStatus as ModerationStatus]
+    if (mappedListingStatus) {
+      apiFilters.listingStatus = mappedListingStatus
+    }
   }
   // Legacy: Status mapping (backward compatible)
   else if (uiFilters.status) {
@@ -262,6 +282,7 @@ const deriveStatusFromVerification = (
 
 const deriveStatusFromListingStatus = (
   listingStatus: SummaryListingStatus | null | undefined,
+  moderationStatus: ModerationStatus | null | undefined,
   verificationStatus: string | null | undefined,
   expired: boolean | null | undefined,
 ): PostStatus => {
@@ -269,14 +290,18 @@ const deriveStatusFromListingStatus = (
     case 'EXPIRED':
       return 'expired'
     case 'IN_REVIEW':
-    case 'RESUBMITTED':
-    case 'PENDING_PAYMENT':
       return 'pending'
+    case 'RESUBMITTED':
+      return 'resubmitted'
+    case 'PENDING_PAYMENT':
+      return 'pending_payment'
     case 'DISPLAYING':
     case 'EXPIRING_SOON':
     case 'VERIFIED':
       return 'approved'
     case 'REJECTED':
+      if (moderationStatus === 'REVISION_REQUIRED') return 'revision_required'
+      if (moderationStatus === 'SUSPENDED') return 'suspended'
       return 'rejected'
     default:
       return deriveStatusFromVerification(verificationStatus, expired)
@@ -333,6 +358,7 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
     expiryDate,
     status: deriveStatusFromListingStatus(
       item.listingStatus,
+      item.moderationStatus,
       item.adminVerification?.verificationStatus,
       item.expired,
     ),


### PR DESCRIPTION
…ration filter

- Expand PostStatus type with resubmitted, revision_required, suspended, pending_payment
- deriveStatusFromListingStatus uses moderationStatus to distinguish REJECTED sub-states
- mapUIFiltersToAPI sends listingStatus alongside moderationStatus (mirrors smartrent-fe pattern)
- PostTable badge shows distinct labels/colors per granular status
- Add vi/en translations for new status values