### PR TITLE
feat(admin): add Clear Membership button in user table

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,5 @@
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" --no-use 2>/dev/null
+nvm use --silent 2>/dev/null || true
+
 npx lint-staged

--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -74,6 +74,7 @@ export const PATHS = {
     GET_PACKAGE_BY_ID: '/v1/admin/memberships/packages/:membershipId',
     UPDATE_PACKAGE: '/v1/admin/memberships/packages/:membershipId',
     DELETE_PACKAGE: '/v1/admin/memberships/packages/:membershipId',
+    CLEAR_USER: '/v1/admin/memberships/users/:userId',
   },
 
   // VIP Tier endpoints

--- a/src/api/services/membership.service.ts
+++ b/src/api/services/membership.service.ts
@@ -106,6 +106,18 @@ export class MembershipService {
 
     return response
   }
+
+  /**
+   * Clear all active memberships for a user (Admin operation)
+   * DELETE /v1/admin/memberships/users/{userId}
+   *
+   * Expires every ACTIVE membership record for the given user.
+   * Use this to fix duplicate-active-membership issues.
+   */
+  static async clearUserMembership(userId: string): Promise<ApiResponse<void>> {
+    const url = ENV.API.MEMBERSHIP.CLEAR_USER.replace(':userId', userId)
+    return apiRequest<void>({ method: 'DELETE', url })
+  }
 }
 
 // Export individual methods for convenience
@@ -114,4 +126,5 @@ export const {
   getMembershipPackageById,
   updateMembershipPackage,
   deleteMembershipPackage,
+  clearUserMembership,
 } = MembershipService

--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -12,12 +12,15 @@ import { UserTable } from '@/components/organisms/users/UserTable'
 import { UserCreateDialog } from '@/components/organisms/users/UserCreateDialog'
 import { UserEditDialog } from '@/components/organisms/users/UserEditDialog'
 import { UserDeleteDialog } from '@/components/organisms/users/UserDeleteDialog'
+import { UserClearMembershipDialog } from '@/components/organisms/users/UserClearMembershipDialog'
 import { PageHeader } from '@/components/molecules/pageHeader'
 
 const UserManagement = () => {
   // Modal states
   const [editingUser, setEditingUser] = useState<UserProfile | null>(null)
   const [showDelete, setShowDelete] = useState<UserProfile | null>(null)
+  const [showClearMembership, setShowClearMembership] =
+    useState<UserProfile | null>(null)
   const [showCreate, setShowCreate] = useState(false)
   const t = useTranslations('admin.users')
 
@@ -163,6 +166,7 @@ const UserManagement = () => {
           onEdit={setEditingUser}
           onDelete={setShowDelete}
           onRemoveBroker={handleRemoveBroker}
+          onClearMembership={setShowClearMembership}
         />
       </div>
 
@@ -195,6 +199,17 @@ const UserManagement = () => {
         onSuccess={(userId) =>
           setUsers((prev) => prev.filter((u) => u.userId !== userId))
         }
+      />
+
+      {/* Clear Membership Modal */}
+      <UserClearMembershipDialog
+        user={showClearMembership}
+        open={!!showClearMembership}
+        onOpenChange={(open) => !open && setShowClearMembership(null)}
+        onSuccess={() => {
+          toast.success(t('clearMembership.success'))
+          setShowClearMembership(null)
+        }}
       />
     </div>
   )

--- a/src/components/organisms/users/UserClearMembershipDialog.tsx
+++ b/src/components/organisms/users/UserClearMembershipDialog.tsx
@@ -1,0 +1,94 @@
+import React, { useState } from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/atoms/dialog'
+import { Button } from '@/components/atoms/button'
+import { useTranslations } from 'next-intl'
+import { clearUserMembership } from '@/api/services/membership.service'
+import { UserProfile } from '@/api/types/user.type'
+
+interface UserClearMembershipDialogProps {
+  user: UserProfile | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess: () => void
+}
+
+export const UserClearMembershipDialog: React.FC<
+  UserClearMembershipDialogProps
+> = ({ user, open, onOpenChange, onSuccess }) => {
+  const t = useTranslations('admin.users')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleConfirm = async () => {
+    if (!user) return
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await clearUserMembership(user.userId)
+      if (resp.success) {
+        onSuccess()
+        onOpenChange(false)
+      } else {
+        setError(resp.message || t('clearMembership.error'))
+      }
+    } catch (err: unknown) {
+      const e = err as { message?: string }
+      setError(e.message || t('clearMembership.error'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const displayName = user
+    ? `${user.firstName} ${user.lastName}`.trim() || user.email
+    : ''
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-sm'>
+        <DialogHeader>
+          <DialogTitle>{t('clearMembership.title')}</DialogTitle>
+          <DialogDescription>{t('clearMembership.subtitle')}</DialogDescription>
+        </DialogHeader>
+        <div className='space-y-3'>
+          <p className='text-sm text-muted-foreground'>
+            {t('clearMembership.confirm')}{' '}
+            <span className='font-semibold text-foreground'>{displayName}</span>
+            {'?'}
+          </p>
+          <p className='text-xs text-muted-foreground'>
+            {t('clearMembership.warning')}
+          </p>
+          {error && <p className='text-sm text-destructive'>{error}</p>}
+          <div className='flex gap-3 pt-2'>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+              className='flex-1'
+            >
+              {t('clearMembership.cancel')}
+            </Button>
+            <Button
+              disabled={loading}
+              onClick={handleConfirm}
+              variant='destructive'
+              className='flex-1'
+            >
+              {loading
+                ? t('clearMembership.clearing')
+                : t('clearMembership.confirm_button')}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/organisms/users/UserTable.tsx
+++ b/src/components/organisms/users/UserTable.tsx
@@ -7,7 +7,7 @@ import {
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
 import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
-import { Pencil, UserX, Trash2 } from 'lucide-react'
+import { Pencil, UserX, Trash2, ShieldOff } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { UserProfile } from '@/api/types/user.type'
 import { UserData } from '@/types/users.type'
@@ -22,6 +22,7 @@ interface UserTableProps {
   onEdit: (user: UserProfile) => void
   onDelete: (user: UserProfile) => void
   onRemoveBroker: (user: UserProfile) => void
+  onClearMembership: (user: UserProfile) => void
 }
 
 export const UserTable: React.FC<UserTableProps> = ({
@@ -33,6 +34,7 @@ export const UserTable: React.FC<UserTableProps> = ({
   onEdit,
   onDelete,
   onRemoveBroker,
+  onClearMembership,
 }) => {
   const t = useTranslations('admin.users')
 
@@ -123,6 +125,17 @@ export const UserTable: React.FC<UserTableProps> = ({
                 <UserX className='h-4 w-4' />
               </Button>
             )}
+            <Button
+              variant='ghost'
+              size='sm'
+              className='h-8 w-8 p-0 text-muted-foreground hover:bg-warning/15 hover:text-warning-foreground'
+              title={t('table.actions.clearMembership')}
+              onClick={() => {
+                if (user) onClearMembership(user)
+              }}
+            >
+              <ShieldOff className='h-4 w-4' />
+            </Button>
             <Button
               variant='ghost'
               size='sm'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -980,7 +980,8 @@
           "removeBroker": "Remove Broker",
           "removeBrokerConfirm": "Remove broker role for {name}?",
           "removeBrokerSuccess": "Broker role removed successfully",
-          "removeBrokerError": "Unable to remove broker role. Please try again."
+          "removeBrokerError": "Unable to remove broker role. Please try again.",
+          "clearMembership": "Clear Membership"
         },
         "loading": "Loading users...",
         "noUsersFound": "No users found"
@@ -1021,6 +1022,17 @@
         "creating": "Creating...",
         "cancel": "Cancel",
         "button": "Create New User"
+      },
+      "clearMembership": {
+        "title": "Clear User Membership",
+        "subtitle": "This will force-expire all active memberships so the user can purchase a new package.",
+        "confirm": "Clear all active memberships for",
+        "warning": "All active membership quotas and benefits will be lost immediately.",
+        "confirm_button": "Clear Membership",
+        "cancel": "Cancel",
+        "clearing": "Clearing...",
+        "success": "Membership cleared successfully. The user can now purchase a new package.",
+        "error": "Failed to clear membership. Please try again."
       }
     },
     "analytics": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -944,7 +944,8 @@
           "removeBroker": "Gỡ môi giới",
           "removeBrokerConfirm": "Bạn có chắc muốn gỡ vai trò môi giới của {name}?",
           "removeBrokerSuccess": "Đã gỡ vai trò môi giới thành công",
-          "removeBrokerError": "Không thể gỡ vai trò môi giới. Vui lòng thử lại."
+          "removeBrokerError": "Không thể gỡ vai trò môi giới. Vui lòng thử lại.",
+          "clearMembership": "Xoá gói hội viên"
         },
         "loading": "Đang tải người dùng...",
         "noUsersFound": "Không tìm thấy người dùng"
@@ -985,6 +986,17 @@
         "creating": "Đang Tạo...",
         "cancel": "Hủy",
         "button": "Tạo Người Dùng Mới"
+      },
+      "clearMembership": {
+        "title": "Xoá gói hội viên",
+        "subtitle": "Thao tác này sẽ buộc hết hạn toàn bộ gói đang active để user có thể mua lại gói mới.",
+        "confirm": "Xoá toàn bộ gói hội viên đang active của",
+        "warning": "Toàn bộ lượt đăng tin và quyền lợi sẽ mất ngay lập tức.",
+        "confirm_button": "Xoá gói",
+        "cancel": "Huỷ",
+        "clearing": "Đang xoá...",
+        "success": "Đã xoá gói thành công. User có thể mua gói mới.",
+        "error": "Không thể xoá gói hội viên. Vui lòng thử lại."
       }
     },
     "analytics": {


### PR DESCRIPTION
Force-expires all active memberships for a user so they can purchase a new package from scratch. Useful for fixing duplicate-active- membership bugs.

- New DELETE /v1/admin/memberships/users/{userId} endpoint (backend)
- ShieldOff icon button in UserTable actions
- UserClearMembershipDialog confirmation dialog
- Translations (en + vi)
- Fix husky pre-commit hook to use Node 20 from .nvmrc