### PR TITLE
chore(i18n): rebrand user-facing Vietnamese 'SmartRent' to 'Thuê Nhà Trọ'

### DIFF
--- a/src/app/(dashboard)/management/transactions/[transactionId]/page.tsx
+++ b/src/app/(dashboard)/management/transactions/[transactionId]/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { TransactionDetailPage } from '@/components/features/transactions'
 
 export const metadata: Metadata = {
-  title: 'Chi tiết giao dịch - SmartRent Admin',
+  title: 'Chi tiết giao dịch - Thuê Nhà Trọ Admin',
   description: 'Xem chi tiết giao dịch thanh toán',
 }
 

--- a/src/app/(dashboard)/management/transactions/dashboard/page.tsx
+++ b/src/app/(dashboard)/management/transactions/dashboard/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { TransactionsDashboardPage } from '@/components/features/transactions'
 
 export const metadata: Metadata = {
-  title: 'Tổng quan giao dịch - SmartRent Admin',
+  title: 'Tổng quan giao dịch - Thuê Nhà Trọ Admin',
   description:
     'Xem tổng quan về doanh thu, tỷ lệ thành công và xu hướng thanh toán',
 }

--- a/src/app/(dashboard)/management/transactions/page.tsx
+++ b/src/app/(dashboard)/management/transactions/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next'
 import { TransactionsPage } from '@/components/features/transactions'
 
 export const metadata: Metadata = {
-  title: 'Quản lý giao dịch - SmartRent Admin',
+  title: 'Quản lý giao dịch - Thuê Nhà Trọ Admin',
   description: 'Xem và quản lý tất cả các giao dịch thanh toán',
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,8 +17,8 @@ const jetBrainsMono = JetBrains_Mono({
 })
 
 export const metadata: Metadata = {
-  title: 'SmartRent Admin',
-  description: 'SmartRent admin dashboard',
+  title: 'Thuê Nhà Trọ Admin',
+  description: 'Bảng điều khiển quản trị Thuê Nhà Trọ',
 }
 
 export default function RootLayout({

--- a/src/components/features/auth/login-page.tsx
+++ b/src/components/features/auth/login-page.tsx
@@ -75,7 +75,7 @@ const LoginPage = () => {
             <Building2 className='h-4 w-4' />
           </div>
           <div className='hidden text-sm font-semibold tracking-tight text-foreground sm:block'>
-            SmartRent
+            Thuê Nhà Trọ
           </div>
         </div>
         <div className='flex items-center gap-1'>
@@ -114,7 +114,7 @@ const LoginPage = () => {
                 <Building2 className='h-7 w-7' />
               </div>
               <h2 className='text-2xl font-semibold tracking-tight text-foreground'>
-                SmartRent
+                Thuê Nhà Trọ
               </h2>
               <p className='mt-2 text-sm text-muted-foreground'>
                 {tBrand('subtitle')}
@@ -122,7 +122,7 @@ const LoginPage = () => {
             </div>
 
             <div className='text-xs text-muted-foreground/70 text-center'>
-              © {new Date().getFullYear()} SmartRent
+              © {new Date().getFullYear()} Thuê Nhà Trọ
             </div>
           </div>
 
@@ -134,7 +134,7 @@ const LoginPage = () => {
                   <Building2 className='h-4 w-4' />
                 </div>
                 <div className='text-base font-semibold tracking-tight'>
-                  SmartRent
+                  Thuê Nhà Trọ
                 </div>
               </div>
 
@@ -152,7 +152,7 @@ const LoginPage = () => {
               </div>
 
               <div className='mt-6 text-center text-xs text-muted-foreground'>
-                SmartRent Admin · v1.0
+                Thuê Nhà Trọ Admin · v1.0
               </div>
             </div>
           </div>

--- a/src/components/organisms/adminSidebar.tsx
+++ b/src/components/organisms/adminSidebar.tsx
@@ -268,7 +268,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
               type='button'
               onClick={() => handleNavigate(DEFAULT_HOME_ROUTE)}
               className='group flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent'
-              aria-label='SmartRent Admin'
+              aria-label='Thuê Nhà Trọ Admin'
             >
               <span
                 aria-hidden
@@ -278,7 +278,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
               </span>
               <span className='flex min-w-0 flex-col leading-tight'>
                 <span className='truncate text-sm font-semibold text-sidebar-foreground'>
-                  SmartRent
+                  Thuê Nhà Trọ
                 </span>
                 <span className='truncate text-[11px] text-muted-foreground'>
                   Admin Console

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -224,7 +224,7 @@
       },
       "brand": {
         "badge": "Bảng điều khiển quản trị",
-        "headline": "Vận hành SmartRent với sự rõ ràng và kiểm soát.",
+        "headline": "Vận hành Thuê Nhà Trọ với sự rõ ràng và kiểm soát.",
         "subheadline": "Quản lý người dùng, tin đăng, gói cao cấp và doanh thu trong một không gian làm việc duy nhất.",
         "subtitle": "Quản lý Bất động sản",
         "secure": "Kết nối bảo mật",
@@ -823,7 +823,7 @@
     "address": "123 Đường Chính, Thành phố Hồ Chí Minh, Việt Nam",
     "phone": "+84 123 456 789",
     "email": "info@smartrent.com",
-    "copyright": "© 2024 SmartRent. Tất cả quyền được bảo lưu.",
+    "copyright": "© 2024 Thuê Nhà Trọ. Tất cả quyền được bảo lưu.",
     "privacy": "Bảo mật",
     "terms": "Điều khoản",
     "followUs": "Theo dõi chúng tôi",
@@ -870,7 +870,7 @@
       "featureInDevelopment": "Chức năng đang phát triển"
     },
     "sidebar": {
-      "title": "SmartRent Admin",
+      "title": "Thuê Nhà Trọ Admin",
       "sections": {
         "management": "Quản Trị"
       },


### PR DESCRIPTION
## Mục tiêu
Admin panel phục vụ **tiếng Việt** (i18n `locale` hardcode `'vi'` trong `src/i18n/request.ts`), nên mọi nhãn brand user nhìn thấy phải là **"Thuê Nhà Trọ"**.

## Đổi (15 chỗ, giữ tiếng Anh & logo)
- `login-page.tsx` — 5 chỗ (top bar, brand h2, copyright, mobile brand, "Admin · v1.0")
- `adminSidebar.tsx` — aria-label + text brand
- `layout.tsx` — tab title + description (đổi sang mô tả VN)
- 3 trang giao dịch — `title` metadata "- Thuê Nhà Trọ Admin"
- `vi.json` — headline, footer copyright, admin.sidebar.title

## Giữ nguyên (theo quy tắc)
- `en.json` (tiếng Anh) → vẫn "SmartRent".
- Logo badge "SR", nhãn "Admin Console", email `*@smartrent.com`, mọi identifier/code.

Không đụng domain (repo không có `smartrent.io.vn`/`smartrent.vn`).