### PR TITLE
chore(admin): remove page-header description subtitles

### DIFF
--- a/src/components/features/admins/admins-page.tsx
+++ b/src/components/features/admins/admins-page.tsx
@@ -100,7 +100,6 @@ const AdminManagement = () => {
       <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
         <PageHeader
           title={t('title')}
-          description={t('subtitle')}
           actions={
             <Button
               className='w-full sm:w-auto'

--- a/src/components/features/premium/premium-section-page.tsx
+++ b/src/components/features/premium/premium-section-page.tsx
@@ -225,17 +225,14 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
     <div className='space-y-6'>
       {section === 'overview' && (
         <>
-          <PageHeader title={t('title')} description={t('description')} />
+          <PageHeader title={t('title')} />
           <PremiumStats stats={stats} />
         </>
       )}
 
       {section === 'membership' && (
         <>
-          <PageHeader
-            title={t('title')}
-            description={t('membership.description')}
-          />
+          <PageHeader title={t('title')} />
 
           <MembershipTable
             memberships={displayMemberships}
@@ -250,10 +247,7 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
 
       {section === 'listing-types' && (
         <>
-          <PageHeader
-            title={t('title')}
-            description={t('listingTypes.description')}
-          />
+          <PageHeader title={t('title')} />
           <ListingTypeTable tiers={apiVIPTiers} loading={vipTiersLoading} />
         </>
       )}

--- a/src/components/features/reports/reports-page.tsx
+++ b/src/components/features/reports/reports-page.tsx
@@ -110,7 +110,7 @@ const ViolationReportManagement = () => {
   return (
     <div className='flex flex-col lg:min-h-0 lg:flex-1'>
       <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
-        <PageHeader title={t('title')} description={t('description')} />
+        <PageHeader title={t('title')} />
 
         {/* Stats Cards */}
         <ReportStats stats={stats} />

--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -113,7 +113,6 @@ const RoleManagement = () => {
       <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
         <PageHeader
           title={t('title')}
-          description={t('subtitle')}
           actions={
             <Button
               className='w-full sm:w-auto'

--- a/src/components/features/transactions/transactions-dashboard-page.tsx
+++ b/src/components/features/transactions/transactions-dashboard-page.tsx
@@ -28,10 +28,7 @@ export const TransactionsDashboardPage = () => {
 
   return (
     <div className='space-y-6'>
-      <PageHeader
-        title={t('dashboard.title')}
-        description={t('dashboard.description')}
-      />
+      <PageHeader title={t('dashboard.title')} />
 
       <div className='flex gap-2'>
         {(['week', 'month', 'quarter'] as const).map((range) => (

--- a/src/components/features/transactions/transactions-page.tsx
+++ b/src/components/features/transactions/transactions-page.tsx
@@ -50,7 +50,7 @@ export const TransactionsPage = () => {
 
   return (
     <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
-      <PageHeader title={t('title')} description={t('description')} />
+      <PageHeader title={t('title')} />
 
       <TransactionStatisticsCards statistics={statistics} />
 


### PR DESCRIPTION
## Summary
Remove the explanatory subtitle under the title on the admin pages for a cleaner header — following the same change already applied to the Users page.

## Pages
- Transactions (`Xem và quản lý tất cả các thanh toán của khách hàng trên nền tảng`)
- Transactions dashboard
- Admins
- Roles
- Reports
- Premium — overview / membership / listing-types

Only the `description` prop on `PageHeader` is removed; titles and actions are unchanged. The now-unused i18n keys are left in place (harmless).

## Verification
- `tsc --noEmit`: 0 errors project-wide.
- ESLint: clean on all changed files.
- Prettier: formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)