### PR TITLE
fix(admin): localize hardcoded English UI strings

### DIFF
--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -102,8 +102,8 @@ const RoleManagement = () => {
     {
       id: 'roleName',
       type: 'search',
-      label: t('table.headers.roleName') || 'Role Name',
-      placeholder: 'e.g. Administrator',
+      label: t('table.headers.roleName'),
+      placeholder: t('table.roleNamePlaceholder'),
       isFilterField: true,
     },
   ]
@@ -137,7 +137,7 @@ const RoleManagement = () => {
           sortable
           defaultSort={{ key: 'id', direction: 'asc' }}
           loading={loading}
-          emptyMessage={loading ? 'Loading roles...' : 'No roles found'}
+          emptyMessage={loading ? t('table.loading') : t('table.empty')}
           getRowKey={(row) => row.id}
           actions={(row) => (
             <div className='flex items-center justify-center gap-0.5'>

--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -74,7 +74,7 @@ const UserManagement = () => {
         setUsers(response.data.data)
         setTotalItems(response.data.totalElements)
       } else {
-        setError(response.message || 'Failed to load users')
+        setError(response.message || t('table.loadError'))
       }
     } catch (err: unknown) {
       const error = err as { message?: string }
@@ -138,7 +138,7 @@ const UserManagement = () => {
             size='sm'
             onClick={() => window.location.reload()}
           >
-            Retry
+            {tCommon('retry')}
           </Button>
         </div>
       </div>
@@ -156,7 +156,7 @@ const UserManagement = () => {
               onClick={() => setShowCreate(true)}
             >
               <Plus className='h-4 w-4' />
-              {t('create.button') || 'Create User'}
+              {t('create.button')}
             </Button>
           }
         />

--- a/src/components/molecules/editor/NewsEditorMenuBar.tsx
+++ b/src/components/molecules/editor/NewsEditorMenuBar.tsx
@@ -108,7 +108,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Bold (Ctrl+B)'
+              title={t('tooltips.bold')}
             >
               <Bold className='h-4 w-4' />
             </Button>
@@ -122,7 +122,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Italic (Ctrl+I)'
+              title={t('tooltips.italic')}
             >
               <Italic className='h-4 w-4' />
             </Button>
@@ -136,7 +136,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Underline (Ctrl+U)'
+              title={t('tooltips.underline')}
             >
               <UnderlineIcon className='h-4 w-4' />
             </Button>
@@ -150,7 +150,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Strikethrough'
+              title={t('tooltips.strikethrough')}
             >
               <Strikethrough className='h-4 w-4' />
             </Button>
@@ -164,7 +164,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Inline Code'
+              title={t('tooltips.inlineCode')}
             >
               <Code className='h-4 w-4' />
             </Button>
@@ -178,7 +178,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Highlight'
+              title={t('tooltips.highlight')}
             >
               <Highlighter className='h-4 w-4' />
             </Button>
@@ -192,7 +192,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Subscript'
+              title={t('tooltips.subscript')}
             >
               <SubscriptIcon className='h-4 w-4' />
             </Button>
@@ -206,13 +206,13 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Superscript'
+              title={t('tooltips.superscript')}
             >
               <SuperscriptIcon className='h-4 w-4' />
             </Button>
             <label
               className='flex h-8 w-8 cursor-pointer items-center justify-center rounded-md hover:bg-accent text-foreground'
-              title='Text Color'
+              title={t('tooltips.textColor')}
             >
               <input
                 type='color'
@@ -228,7 +228,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               onClick={() =>
                 editor.chain().focus().unsetColor().unsetAllMarks().run()
               }
-              title='Clear Formatting'
+              title={t('tooltips.clearFormatting')}
             >
               <Eraser className='h-4 w-4' />
             </Button>
@@ -248,7 +248,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Heading 1'
+              title={t('tooltips.heading1')}
             >
               <Heading1 className='h-4 w-4' />
             </Button>
@@ -264,7 +264,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Heading 2'
+              title={t('tooltips.heading2')}
             >
               <Heading2 className='h-4 w-4' />
             </Button>
@@ -280,7 +280,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Heading 3'
+              title={t('tooltips.heading3')}
             >
               <Heading3 className='h-4 w-4' />
             </Button>
@@ -298,7 +298,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Bullet List'
+              title={t('tooltips.bulletList')}
             >
               <List className='h-4 w-4' />
             </Button>
@@ -312,7 +312,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Numbered List'
+              title={t('tooltips.numberedList')}
             >
               <ListOrdered className='h-4 w-4' />
             </Button>
@@ -326,7 +326,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Task List'
+              title={t('tooltips.taskList')}
             >
               <ListTodo className='h-4 w-4' />
             </Button>
@@ -344,7 +344,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Align Left'
+              title={t('tooltips.alignLeft')}
             >
               <AlignLeft className='h-4 w-4' />
             </Button>
@@ -360,7 +360,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Align Center'
+              title={t('tooltips.alignCenter')}
             >
               <AlignCenter className='h-4 w-4' />
             </Button>
@@ -374,7 +374,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Align Right'
+              title={t('tooltips.alignRight')}
             >
               <AlignRight className='h-4 w-4' />
             </Button>
@@ -390,7 +390,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Justify'
+              title={t('tooltips.justify')}
             >
               <AlignJustify className='h-4 w-4' />
             </Button>
@@ -404,7 +404,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={onSelectImage}
               disabled={!onSelectImage || isUploadingImage}
-              title='Insert Image'
+              title={t('tooltips.insertImage')}
             >
               {isUploadingImage ? (
                 <Loader2 className='h-4 w-4 animate-spin' />
@@ -422,7 +422,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Insert Link'
+              title={t('tooltips.insertLink')}
             >
               <LinkIcon className='h-4 w-4' />
             </Button>
@@ -436,7 +436,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   ? 'bg-primary/12 text-primary ring-1 ring-primary/20'
                   : ''
               }
-              title='Quote'
+              title={t('tooltips.quote')}
             >
               <Quote className='h-4 w-4' />
             </Button>
@@ -445,7 +445,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               variant='ghost'
               size='sm'
               onClick={() => editor.chain().focus().setHorizontalRule().run()}
-              title='Horizontal Rule'
+              title={t('tooltips.horizontalRule')}
             >
               <Minus className='h-4 w-4' />
             </Button>
@@ -464,7 +464,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
                   .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
                   .run()
               }
-              title='Insert Table'
+              title={t('tooltips.insertTable')}
             >
               <Table className='h-4 w-4' />
             </Button>
@@ -474,7 +474,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().addRowAfter().run()}
               disabled={!isInTable}
-              title='Add Row'
+              title={t('tooltips.addRow')}
             >
               <Rows3 className='h-4 w-4' />
             </Button>
@@ -484,7 +484,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().deleteRow().run()}
               disabled={!isInTable}
-              title='Delete Row'
+              title={t('tooltips.deleteRow')}
             >
               <Rows3 className='h-4 w-4 text-red-600' />
             </Button>
@@ -494,7 +494,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().addColumnAfter().run()}
               disabled={!isInTable}
-              title='Add Column'
+              title={t('tooltips.addColumn')}
             >
               <Columns3 className='h-4 w-4' />
             </Button>
@@ -504,7 +504,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().deleteColumn().run()}
               disabled={!isInTable}
-              title='Delete Column'
+              title={t('tooltips.deleteColumn')}
             >
               <Columns3 className='h-4 w-4 text-red-600' />
             </Button>
@@ -514,7 +514,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().duplicateRow(true).run()}
               disabled={!isInTable}
-              title='Duplicate Row'
+              title={t('tooltips.duplicateRow')}
             >
               <CopyPlus className='h-4 w-4' />
             </Button>
@@ -524,7 +524,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().duplicateColumn(true).run()}
               disabled={!isInTable}
-              title='Duplicate Column'
+              title={t('tooltips.duplicateColumn')}
             >
               <CopyPlus className='h-4 w-4 rotate-90' />
             </Button>
@@ -534,7 +534,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().mergeCells().run()}
               disabled={!isInTable}
-              title='Merge Cells'
+              title={t('tooltips.mergeCells')}
             >
               <Merge className='h-4 w-4' />
             </Button>
@@ -544,7 +544,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().splitCell().run()}
               disabled={!isInTable}
-              title='Split Cell'
+              title={t('tooltips.splitCell')}
             >
               <Split className='h-4 w-4' />
             </Button>
@@ -554,7 +554,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().toggleHeaderRow().run()}
               disabled={!isInTable}
-              title='Toggle Header Row'
+              title={t('tooltips.toggleHeaderRow')}
             >
               <span className='text-xs font-medium'>HR</span>
             </Button>
@@ -564,7 +564,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().toggleHeaderColumn().run()}
               disabled={!isInTable}
-              title='Toggle Header Column'
+              title={t('tooltips.toggleHeaderColumn')}
             >
               <span className='text-xs font-medium'>HC</span>
             </Button>
@@ -574,7 +574,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().deleteTable().run()}
               disabled={!isInTable}
-              title='Delete Table'
+              title={t('tooltips.deleteTable')}
             >
               <Trash2 className='h-4 w-4' />
             </Button>
@@ -588,7 +588,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().undo().run()}
               disabled={!editor.can().undo()}
-              title='Undo (Ctrl+Z)'
+              title={t('tooltips.undo')}
             >
               <Undo className='h-4 w-4' />
             </Button>
@@ -598,7 +598,7 @@ export const NewsEditorMenuBar: React.FC<NewsEditorMenuBarProps> = ({
               size='sm'
               onClick={() => editor.chain().focus().redo().run()}
               disabled={!editor.can().redo()}
-              title='Redo (Ctrl+Y)'
+              title={t('tooltips.redo')}
             >
               <Redo className='h-4 w-4' />
             </Button>

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -15,16 +15,16 @@ import { PostStatus, UIPostData } from '@/types/posts.type'
 import { getPropertyIcon, getStatusColor } from '@/utils/post.utils'
 import { TIER_STYLES, FALLBACK_TIER_STYLE } from '@/utils/premium.utils'
 
-const TIER_LABEL_OVERRIDES: Record<string, string> = {
-  NORMAL: 'Thường',
-  SILVER: 'Bạc',
-  GOLD: 'Vàng',
-  DIAMOND: 'Kim cương',
-}
-
 const VipTypeBadge: React.FC<{ vipType: string }> = ({ vipType }) => {
+  const t = useTranslations('posts.filters')
   const style = TIER_STYLES[vipType] ?? FALLBACK_TIER_STYLE
-  const label = TIER_LABEL_OVERRIDES[vipType] ?? vipType
+  const labels: Record<string, string> = {
+    NORMAL: t('vipNormal'),
+    SILVER: t('vipSilver'),
+    GOLD: t('vipGold'),
+    DIAMOND: t('vipDiamond'),
+  }
+  const label = labels[vipType] ?? vipType
   return (
     <Badge
       variant='outline'
@@ -37,12 +37,6 @@ const VipTypeBadge: React.FC<{ vipType: string }> = ({ vipType }) => {
     </Badge>
   )
 }
-
-// Re-implementing helper functions that need translations inside the component or pass t
-// Since utils cannot use hooks directly unless valid custom hook.
-// The utils I created in previous step used JSX but not translations for labels.
-// getPropertyTypeLabel in posts.tsx used t().
-// I should probably move the label logic back here or pass t to utils if possible (but utils are functions).
 
 interface PostTableProps {
   data: UIPostData[]

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3,7 +3,8 @@
     "or": "Or",
     "noData": "No data",
     "total": "Total",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "retry": "Retry"
   },
   "notFound": {
     "title": "404",
@@ -985,7 +986,8 @@
           "clearMembership": "Clear Membership"
         },
         "loading": "Loading users...",
-        "noUsersFound": "No users found"
+        "noUsersFound": "No users found",
+        "loadError": "Failed to load users"
       },
       "delete": {
         "title": "Delete User",
@@ -1420,7 +1422,10 @@
         "actions": {
           "edit": "Edit",
           "delete": "Delete"
-        }
+        },
+        "roleNamePlaceholder": "e.g. Administrator",
+        "loading": "Loading roles...",
+        "empty": "No roles found"
       },
       "create": {
         "title": "Create Role",
@@ -2134,7 +2139,47 @@
       "menuBar": {
         "enterUrl": "Enter URL:",
         "linkTitle": "Insert link",
-        "insert": "Insert"
+        "insert": "Insert",
+        "tooltips": {
+          "bold": "Bold (Ctrl+B)",
+          "italic": "Italic (Ctrl+I)",
+          "underline": "Underline (Ctrl+U)",
+          "strikethrough": "Strikethrough",
+          "inlineCode": "Inline Code",
+          "highlight": "Highlight",
+          "subscript": "Subscript",
+          "superscript": "Superscript",
+          "textColor": "Text Color",
+          "clearFormatting": "Clear Formatting",
+          "heading1": "Heading 1",
+          "heading2": "Heading 2",
+          "heading3": "Heading 3",
+          "bulletList": "Bullet List",
+          "numberedList": "Numbered List",
+          "taskList": "Task List",
+          "alignLeft": "Align Left",
+          "alignCenter": "Align Center",
+          "alignRight": "Align Right",
+          "justify": "Justify",
+          "insertImage": "Insert Image",
+          "insertLink": "Insert Link",
+          "quote": "Quote",
+          "horizontalRule": "Horizontal Rule",
+          "insertTable": "Insert Table",
+          "addRow": "Add Row",
+          "deleteRow": "Delete Row",
+          "addColumn": "Add Column",
+          "deleteColumn": "Delete Column",
+          "duplicateRow": "Duplicate Row",
+          "duplicateColumn": "Duplicate Column",
+          "mergeCells": "Merge Cells",
+          "splitCell": "Split Cell",
+          "toggleHeaderRow": "Toggle Header Row",
+          "toggleHeaderColumn": "Toggle Header Column",
+          "deleteTable": "Delete Table",
+          "undo": "Undo (Ctrl+Z)",
+          "redo": "Redo (Ctrl+Y)"
+        }
       },
       "validation": {
         "titleRequired": "Title is required"

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -3,7 +3,8 @@
     "or": "Hoặc",
     "noData": "Không có dữ liệu",
     "total": "Tổng",
-    "cancel": "Hủy"
+    "cancel": "Hủy",
+    "retry": "Thử lại"
   },
   "notFound": {
     "title": "404",
@@ -949,7 +950,8 @@
           "clearMembership": "Xoá gói hội viên"
         },
         "loading": "Đang tải người dùng...",
-        "noUsersFound": "Không tìm thấy người dùng"
+        "noUsersFound": "Không tìm thấy người dùng",
+        "loadError": "Không thể tải danh sách người dùng"
       },
       "delete": {
         "title": "Xóa Người Dùng",
@@ -1384,7 +1386,10 @@
         "actions": {
           "edit": "Chỉnh sửa",
           "delete": "Xóa"
-        }
+        },
+        "roleNamePlaceholder": "VD: Quản trị viên",
+        "loading": "Đang tải vai trò...",
+        "empty": "Không tìm thấy vai trò"
       },
       "create": {
         "title": "Tạo Vai Trò",
@@ -2098,7 +2103,47 @@
       "menuBar": {
         "enterUrl": "Nhập URL:",
         "linkTitle": "Chèn liên kết",
-        "insert": "Chèn"
+        "insert": "Chèn",
+        "tooltips": {
+          "bold": "Đậm (Ctrl+B)",
+          "italic": "Nghiêng (Ctrl+I)",
+          "underline": "Gạch chân (Ctrl+U)",
+          "strikethrough": "Gạch ngang",
+          "inlineCode": "Mã nội dòng",
+          "highlight": "Tô sáng",
+          "subscript": "Chỉ số dưới",
+          "superscript": "Chỉ số trên",
+          "textColor": "Màu chữ",
+          "clearFormatting": "Xóa định dạng",
+          "heading1": "Tiêu đề 1",
+          "heading2": "Tiêu đề 2",
+          "heading3": "Tiêu đề 3",
+          "bulletList": "Danh sách dấu đầu dòng",
+          "numberedList": "Danh sách đánh số",
+          "taskList": "Danh sách công việc",
+          "alignLeft": "Căn trái",
+          "alignCenter": "Căn giữa",
+          "alignRight": "Căn phải",
+          "justify": "Căn đều",
+          "insertImage": "Chèn ảnh",
+          "insertLink": "Chèn liên kết",
+          "quote": "Trích dẫn",
+          "horizontalRule": "Đường kẻ ngang",
+          "insertTable": "Chèn bảng",
+          "addRow": "Thêm hàng",
+          "deleteRow": "Xóa hàng",
+          "addColumn": "Thêm cột",
+          "deleteColumn": "Xóa cột",
+          "duplicateRow": "Nhân đôi hàng",
+          "duplicateColumn": "Nhân đôi cột",
+          "mergeCells": "Gộp ô",
+          "splitCell": "Tách ô",
+          "toggleHeaderRow": "Bật/tắt hàng tiêu đề",
+          "toggleHeaderColumn": "Bật/tắt cột tiêu đề",
+          "deleteTable": "Xóa bảng",
+          "undo": "Hoàn tác (Ctrl+Z)",
+          "redo": "Làm lại (Ctrl+Y)"
+        }
       },
       "validation": {
         "titleRequired": "Tiêu đề là bắt buộc"


### PR DESCRIPTION
## Summary
Second batch from the admin UI audit — localizes the visible English strings leaking into this Vietnamese-first admin.

## Changes
- **News editor toolbar** — all **38 English `title` tooltips** (`Bold (Ctrl+B)`, `Insert Table`, `Merge Cells`, …) moved into i18n under `news.editor.menuBar.tooltips` (en + vi). The file already localized its link dialog, so this removes the inconsistency.
- **PostTable tier badges** — `VipTypeBadge` now reads the existing `posts.filters.vip*` keys instead of a hardcoded Vietnamese label map (which showed Vietnamese even in the EN locale). Also drops a stale dev comment.
- **users-page** — `Retry` button → `common.retry`; raw `'Failed to load users'` fallback → `admin.users.table.loadError`; dropped the `|| 'Create User'` English fallback.
- **roles-page** — role-name search placeholder (`e.g. Administrator`) and the `Loading roles...` / `No roles found` table messages → `admin.roles.table.*`; dropped the `|| 'Role Name'` fallback.
- Added the supporting keys to `en.json` + `vi.json`.

## Verification
- `tsc --noEmit`: 0 errors project-wide.
- ESLint: clean on all changed files.
- Prettier: formatted (JSON diff kept minimal).

## Deferred (optional follow-up)
Lower-visibility i18n polish, not included here:
- Hardcoded English `aria-label`/`alt` on chrome (header menu, pagination, month/theme/language toggles, thumbnail).
- vi.json spelling/casing normalization (`Huỷ`/`Hủy`, `Xoá`/`Xóa`, `Xóa Bộ lọc`/`Xóa Bộ Lọc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)