### PR TITLE
fix(admin): news editor body height no longer cramps on short screens

### DIFF
--- a/src/components/features/news/news-editor-page.tsx
+++ b/src/components/features/news/news-editor-page.tsx
@@ -433,7 +433,7 @@ const NewsEditor = () => {
                     onSelectImage={() => contentImageInputRef.current?.click()}
                     isUploadingImage={uploadingContentImage}
                   />
-                  <div className='min-h-[50vh] max-h-[50vh] overflow-y-auto'>
+                  <div className='min-h-[420px] max-h-[60vh] overflow-y-auto'>
                     <EditorContent editor={editor} />
                   </div>
                 </>


### PR DESCRIPTION
## Summary
Layout batch from the admin audit. Ships the one layout fix I can make safely without a live render; the rest are intentionally deferred (see below).

## Change
- **News editor** — the content scroll area was locked to `min-h-[50vh] max-h-[50vh]` while the TipTap surface inside has `min-h-[420px]`. On viewports shorter than ~840px, `50vh < 420px`, so the inner minimum forced a permanent scrollbar and a cramped editor; on tall screens it never grew past 50vh. Changed to `min-h-[420px] max-h-[60vh]` — never smaller than the content minimum (no cramping), caps at 60vh with internal scroll for long documents, and uses more vertical space on tall screens.

## Verification
- `tsc --noEmit`: 0 errors project-wide.
- ESLint: clean. Prettier: formatted.

## Deferred — need visual QA against a running app
These audit items are real but are responsive/visual tweaks that can regress at specific breakpoints; I don't want to blind-apply them without rendering:
- **Unify stat cards** — Overview/Revenue analytics tabs use the older `StatsCard` while other tabs use `StatCard`; they have different APIs (icon type, trend shape, badge), so it's a refactor that needs a visual pass.
- **Pie chart squash/overflow** — `pieChartCard` donut collapses beside the 180px legend in the ~1024–1200px range, and a fixed body height can clip 4+ legend rows. The fix depends on `ChartCard` bodyHeight × legend count and needs breakpoint testing.
- **Long KPI value wrap** — currency values can wrap to two lines; truncating would hide the amount (bad UX) and grid rows already stay equal-height, so this is cosmetic.

Happy to do these next if you can run the app (`corepack yarn dev`) so we can verify visually.