### PR TITLE
refactor(admin): document-scroll for list tables (replace fillHeight)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-admin-table-document-scroll.md
+++ b/docs/superpowers/plans/2026-07-11-admin-table-document-scroll.md
@@ -1,0 +1,340 @@
+# Admin Table Document-Scroll — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `fillHeight` fixed-viewport internal-scroll model on admin list pages with document-scroll (the page scrolls; the table renders at natural height; wide tables scroll horizontally inside their card).
+
+**Architecture:** Revert the flex-fill plumbing (layout `main`/`.app-container`, `DataTable` `fillHeight`, per-page `lg:min-h-0 lg:flex-1` wrappers) and replace the table body's viewport-fraction height + inner vertical scroll with a single inner `overflow-x-auto` wrapper. No sticky header (a wide table's horizontal-scroll container also captures the vertical axis, so page-relative sticky is impossible).
+
+**Tech Stack:** Next.js App Router, React, Tailwind, TypeScript. Package manager: **Yarn 4 via Corepack** — run every tooling command as `corepack yarn <cmd>` (global `yarn` is 1.x and fails). No unit-test harness for layout/CSS (`test` script is a no-op), so per-task verification is **static** (grep assertions + `tsc` + ESLint) plus a final visual check.
+
+## Global Constraints
+- Run tooling as `corepack yarn tsc --noEmit` / `corepack yarn eslint <files>`; format with `npx prettier --write <files>`.
+- After every task: `corepack yarn tsc --noEmit` must report **0 errors** project-wide, and ESLint must be clean on the changed files.
+- Do not touch `src/styles/globals.css` (`.table-surface` keeps `overflow-hidden`).
+- Do not touch premium tables, mobile card view (`TableMobile`), or the pagination component.
+- Branch: `refactor/admin-table-document-scroll` (already created off `origin/main`).
+
+---
+
+### Task 1: Revert layout scroll container
+
+**Files:**
+- Modify: `src/components/layouts/AppAdminLayout.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `main` is a plain block scroll container; `.app-container` is a plain block. No flex-fill for descendants to hook into.
+
+- [ ] **Step 1: Edit the layout**
+
+Replace:
+```tsx
+        <div className='flex-1 overflow-hidden'>
+          <main className='flex h-full w-full flex-col overflow-y-auto'>
+            <div className='app-container flex flex-col lg:min-h-0 lg:flex-1'>
+              {children}
+            </div>
+          </main>
+        </div>
+```
+with:
+```tsx
+        <div className='flex-1 overflow-hidden'>
+          <main className='h-full w-full overflow-y-auto'>
+            <div className='app-container'>{children}</div>
+          </main>
+        </div>
+```
+
+- [ ] **Step 2: Verify + format**
+
+Run:
+```bash
+grep -n "lg:min-h-0\|flex flex-col overflow-y-auto" src/components/layouts/AppAdminLayout.tsx || echo "OK: flex-fill removed"
+npx prettier --write src/components/layouts/AppAdminLayout.tsx
+corepack yarn tsc --noEmit 2>&1 | grep -cE 'error TS'
+```
+Expected: "OK: flex-fill removed" and tsc count `0`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/layouts/AppAdminLayout.tsx
+git commit -m "refactor(admin): revert layout to plain document scroll"
+```
+
+---
+
+### Task 2: Remove `fillHeight` usage from table organisms + roles inline table
+
+**Files:**
+- Modify: `src/components/organisms/users/UserTable.tsx`
+- Modify: `src/components/organisms/admins/AdminTable.tsx`
+- Modify: `src/components/organisms/reports/ReportTable.tsx`
+- Modify: `src/components/organisms/news/NewsTable.tsx`
+- Modify: `src/components/organisms/posts/PostTable.tsx`
+- Modify: `src/components/organisms/brokers/BrokerPendingTable.tsx`
+- Modify: `src/components/organisms/transactions/AdminTransactionTable.tsx`
+- Modify: `src/components/features/roles/roles-page.tsx`
+
+**Interfaces:**
+- Consumes: `DataTable` still declares `fillHeight` (removed later in Task 4).
+- Produces: no component passes `fillHeight` any more.
+
+- [ ] **Step 1: Remove the `fillHeight` line in each `<DataTable>` call**
+
+In each of the 7 organism files, delete the standalone `fillHeight` prop line (it sits right after `<DataTable` / `<DataTable<AdminTransaction>`):
+```tsx
+      fillHeight
+```
+In `ReportTable.tsx` it is inline — change:
+```tsx
+    <DataTable fillHeight columns={columns} data={data} loading={loading} />
+```
+to:
+```tsx
+    <DataTable columns={columns} data={data} loading={loading} />
+```
+In `roles-page.tsx` delete the `fillHeight` line inside its `<DataTable>` (after `<DataTable`):
+```tsx
+          fillHeight
+```
+
+- [ ] **Step 2: Verify no `fillHeight` usage remains outside DataTable internals**
+
+Run:
+```bash
+grep -rn "fillHeight" src --include=*.tsx | grep -v "DataTable/index.tsx\|DataTable/TableDesktop.tsx\|DataTable/types.ts"
+```
+Expected: **no output** (all call-site usages gone).
+
+- [ ] **Step 3: Format + typecheck**
+
+```bash
+npx prettier --write src/components/organisms/*/[A-Z]*Table.tsx src/components/features/roles/roles-page.tsx
+corepack yarn tsc --noEmit 2>&1 | grep -cE 'error TS'
+```
+Expected: `0`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(admin): stop passing fillHeight from list tables"
+```
+
+---
+
+### Task 3: Revert flex-fill wrappers on the list pages
+
+**Files:**
+- Modify: `src/components/features/users/users-page.tsx`
+- Modify: `src/components/features/admins/admins-page.tsx`
+- Modify: `src/components/features/roles/roles-page.tsx`
+- Modify: `src/components/features/reports/reports-page.tsx`
+- Modify: `src/components/features/brokers/broker-pending-page.tsx`
+- Modify: `src/components/features/posts/posts-page.tsx`
+- Modify: `src/components/features/news/news-page.tsx`
+- Modify: `src/components/features/transactions/transactions-page.tsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: pages use plain block wrappers; content flows for document scroll.
+
+- [ ] **Step 1: Root + inner wrapper pattern (users, admins, roles, reports, broker-pending)**
+
+In each, replace the two fill wrappers:
+```tsx
+    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
+      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+```
+with:
+```tsx
+    <div>
+      <div className='space-y-6'>
+```
+(These files' closing `</div></div>` stay unchanged.)
+
+- [ ] **Step 2: Single-root pattern (transactions)**
+
+In `transactions-page.tsx` replace:
+```tsx
+    <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+```
+with:
+```tsx
+    <div className='space-y-6'>
+```
+
+- [ ] **Step 3: Loader-conditional pattern (posts, news)**
+
+In `posts-page.tsx` and `news-page.tsx` replace the root:
+```tsx
+    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
+```
+with:
+```tsx
+    <div>
+```
+and the loaded branch:
+```tsx
+        <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+```
+with:
+```tsx
+        <div className='space-y-6'>
+```
+
+- [ ] **Step 4: Verify no fill chain remains on pages, format, typecheck**
+
+```bash
+grep -rn "lg:min-h-0\|lg:flex-1" src/components/features || echo "OK: no fill chain on pages"
+npx prettier --write src/components/features/*/*-page.tsx
+corepack yarn eslint src/components/features/*/*-page.tsx; echo "ESLINT $?"
+corepack yarn tsc --noEmit 2>&1 | grep -cE 'error TS'
+```
+Expected: "OK: no fill chain on pages", ESLINT `0`, tsc `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(admin): revert list-page wrappers to plain document flow"
+```
+
+---
+
+### Task 4: Simplify DataTable core (natural-height body + horizontal scroll)
+
+**Files:**
+- Modify: `src/components/organisms/DataTable/types.ts`
+- Modify: `src/components/organisms/DataTable/index.tsx`
+- Modify: `src/components/organisms/DataTable/TableDesktop.tsx`
+
+**Interfaces:**
+- Consumes: no call site passes `fillHeight` or `tableClassName` (verified in Task 2; `tableClassName` was never passed by any caller).
+- Produces: `DataTable`/`TableDesktop` no longer accept `fillHeight`, `tableClassName`, or `maxHeightClassName`; the desktop table renders at natural height inside an `overflow-x-auto` wrapper.
+
+- [ ] **Step 1: `types.ts` — drop `fillHeight`, `tableClassName`, `maxHeightClassName`**
+
+In `DataTableProps`, delete the `fillHeight` doc-comment + field and the `tableClassName?: string` line:
+```tsx
+  // Styling
+  className?: string
+
+  // Key extractor
+  getRowKey?: (row: T, index: number) => string | number
+```
+(i.e. remove `tableClassName?: string` and the whole `/** Fill the available… */ fillHeight?: boolean` block, keeping `className?`.)
+
+In `TableDesktopProps`, delete these two lines:
+```tsx
+  maxHeightClassName?: string
+  fillHeight?: boolean
+```
+
+- [ ] **Step 2: `index.tsx` — remove `fillHeight` plumbing, root back to `space-y-4`**
+
+Remove `fillHeight = false,` from the `DataTableContent` destructure. Replace the root element:
+```tsx
+    <div
+      className={
+        fillHeight ? 'flex flex-col gap-4 lg:min-h-0 lg:flex-1' : 'space-y-4'
+      }
+    >
+```
+with:
+```tsx
+    <div className='space-y-4'>
+```
+Remove the `maxHeightClassName={tableClassName}` and `fillHeight={fillHeight}` props from the `<TableDesktop … />` call (delete both lines). Also remove `tableClassName,` from the `DataTableContent` destructure list.
+
+- [ ] **Step 3: `TableDesktop.tsx` — natural height + inner `overflow-x-auto`**
+
+Remove `maxHeightClassName,` and `fillHeight,` from the `TableDesktop` destructure. Replace the wrapper block:
+```tsx
+  return (
+    <div
+      className={
+        fillHeight
+          ? 'table-surface hidden lg:flex lg:min-h-0 lg:flex-1 lg:flex-col'
+          : 'table-surface hidden lg:block'
+      }
+    >
+      <div
+        className={
+          fillHeight
+            ? 'min-h-0 flex-1 overflow-y-auto'
+            : `overflow-y-auto ${
+                maxHeightClassName || 'h-[50vh] xl:h-[56vh] 2xl:h-[60vh]'
+              }`
+        }
+      >
+```
+with:
+```tsx
+  return (
+    <div className='table-surface hidden lg:block'>
+      <div className='overflow-x-auto'>
+```
+(The `<table>` and everything below is unchanged. The existing `sticky top-0` on `<thead>` is left as-is — inert without a bounded scroll parent.)
+
+- [ ] **Step 4: Verify, format, typecheck, lint**
+
+```bash
+grep -rn "fillHeight\|maxHeightClassName\|tableClassName\|h-\[50vh\]" src/components/organisms/DataTable || echo "OK: fillHeight/height override fully removed"
+npx prettier --write src/components/organisms/DataTable/types.ts src/components/organisms/DataTable/index.tsx src/components/organisms/DataTable/TableDesktop.tsx
+corepack yarn eslint src/components/organisms/DataTable/*.ts src/components/organisms/DataTable/*.tsx; echo "ESLINT $?"
+corepack yarn tsc --noEmit 2>&1 | grep -cE 'error TS'
+```
+Expected: "OK: fillHeight/height override fully removed", ESLINT `0`, tsc `0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "refactor(admin): DataTable renders at natural height with horizontal scroll"
+```
+
+---
+
+### Task 5: Full verification + visual check
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Project-wide static gate**
+
+```bash
+corepack yarn tsc --noEmit 2>&1 | grep -cE 'error TS'   # expect 0
+corepack yarn eslint src 2>&1 | tail -5                 # expect clean
+grep -rn "fillHeight" src || echo "OK: no fillHeight anywhere"
+```
+Expected: tsc `0`, ESLint clean, "OK: no fillHeight anywhere".
+
+- [ ] **Step 2: Visual check (requires running app)**
+
+```bash
+corepack yarn dev
+```
+Open a list page (e.g. `/management/users`) at a 16:9 window and confirm the acceptance criteria:
+- Table shows all 20 rows at natural height; scrolling the **page** reveals rows then pagination at the end — no nested vertical scrollbar inside the table.
+- A wide table (`/management/transactions` or `/content/posts`) scrolls **horizontally** inside its card on a narrower desktop width; no page-level horizontal scroll.
+- Mobile width (< lg) still shows the card list, unchanged.
+
+- [ ] **Step 3: Push + open PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "refactor(admin): document-scroll for list tables" --body "See docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Scroll model → Tasks 1,3,4. Natural-height body + horizontal scroll → Task 4. Remove `fillHeight` everywhere → Tasks 2,4. Revert flex-fill wrappers → Tasks 1,3. Density/page-size unchanged → no task needed (nothing touches pagination options). Acceptance criteria → Task 5. No sticky header → Task 4 (inner `overflow-x-auto`, thead left inert). All spec sections covered.
+
+**Placeholder scan:** none — every step has exact paths, code, and commands.
+
+**Type consistency:** `fillHeight`, `tableClassName`, `maxHeightClassName` are removed in the same task (4) across `types.ts`/`index.tsx`/`TableDesktop.tsx`; call sites are cleared first (Task 2) so no reference outlives its declaration.

--- a/docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md
@@ -1,0 +1,86 @@
+# Admin data tables — document-scroll layout
+
+**Date:** 2026-07-11
+**Status:** Approved (design)
+
+## Problem
+
+The admin list pages currently use a `fillHeight` approach: the shared
+`DataTable` body flex-fills exactly one viewport and scrolls **internally**,
+with pagination pinned to the bottom of that fixed frame. This constrains how
+many rows are visible (~8–10), adds a nested scrollbar, and limits the user's
+view of the data ("chỉ 1 màn hình, cuộn trong khung"). We want the standard
+modern SaaS pattern (Stripe / GitHub / Vercel): the page scrolls as one
+document and the table shows all rows of the current page at natural height,
+with sticky column headers.
+
+## Goal
+
+Replace the fixed-viewport internal-scroll model with **document-scroll** for
+all paginated admin list pages. Net result should be *less* code than today and
+no viewport-fraction (`vh`) sizing.
+
+## Design
+
+### 1. Scroll model
+- `main` (in `AppAdminLayout`) stays the single scroll container
+  (`overflow-y-auto`) but reverts to plain block flow — remove the
+  `flex flex-col` on `main` and the `lg:min-h-0 lg:flex-1 flex flex-col` on the
+  `.app-container` wrapper that were added for `fillHeight`.
+- The `DataTable` body renders at **natural height**: remove the `fillHeight`
+  prop and its branch logic, remove the inner `overflow-y-auto` wrapper and the
+  `h-[50vh] xl:h-[56vh] 2xl:h-[60vh]` / `flex-1 min-h-0` height rules. The rows
+  determine the table's height; the page scrolls.
+- Pagination sits at the natural end of the list.
+- Remove the `fillHeight` opt-in from every list page + table organism and
+  revert their wrappers (`flex flex-col lg:min-h-0 lg:flex-1` → the original
+  simple wrappers, e.g. `space-y-6`).
+
+### 2. Sticky column header (the UX highlight)
+- `<thead>` is `sticky top-0 z-10` relative to the page scroll (`main`), with a
+  solid background + a bottom hairline so column names stay visible while
+  scrolling rows. (`<thead>` already has `sticky top-0`; today it sticks inside
+  the nested scroll div — after removing that div it must stick to `main`.)
+- **Constraint:** `position: sticky` is disabled by an ancestor with
+  `overflow: hidden/clip/auto`. The `.table-surface` card uses `overflow-hidden`
+  for rounded corners, which sits between `<thead>` and `main`. The
+  implementation must preserve the rounded card while letting the sticky work —
+  e.g. drop the clip and round the first/last header cells, or clip only the
+  x-axis. (Exact CSS technique decided in the plan.)
+- No manual `top` offset needed: the app topbar is fixed **outside** `main`, so
+  `top-0` sticks just beneath it.
+- The page title + Filter/Views toolbar **scroll away naturally** (not sticky).
+
+### 3. Density & page size
+- Keep default page size **20** and the **10 / 20 / 50** options (users who want
+  to see more pick 50).
+- Keep current row density.
+
+## Scope (files)
+- `src/components/layouts/AppAdminLayout.tsx` — revert `main` / `.app-container`
+  flex-fill.
+- `src/components/organisms/DataTable/{types.ts,index.tsx,TableDesktop.tsx}` —
+  remove `fillHeight`; natural-height body; sticky `<thead>`; fix
+  `.table-surface` overflow so sticky works.
+- List pages + their table organisms — remove `fillHeight` and revert flex-fill
+  wrappers: **users, admins, roles, reports, posts, news, transactions,
+  broker-pending** (page + organism where applicable).
+- `src/styles/globals.css` — `.table-surface` overflow handling if changed
+  there.
+
+## Non-goals
+- Sticky filter/toolbar bar (deferred enhancement).
+- Infinite scroll / row virtualization.
+- Changing the pagination component or the page-size options.
+- Premium / config tables (already excluded from `fillHeight`; untouched).
+- Mobile card view (unchanged).
+
+## Acceptance criteria
+- On a list page (e.g. Users) at 16:9, the table shows all 20 rows at natural
+  height; scrolling the page reveals the rows then pagination at the end — **no
+  nested scrollbar inside the table**.
+- Column headers stay visible (sticky) while scrolling rows.
+- No leftover `fillHeight` prop, no `h-[..vh]` on the table body, no
+  `lg:min-h-0 lg:flex-1` fill chain on list pages.
+- `tsc --noEmit`, ESLint, Prettier all clean.
+- Mobile card view unaffected.

--- a/docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md
+++ b/docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md
@@ -36,20 +36,21 @@ no viewport-fraction (`vh`) sizing.
   revert their wrappers (`flex flex-col lg:min-h-0 lg:flex-1` → the original
   simple wrappers, e.g. `space-y-6`).
 
-### 2. Sticky column header (the UX highlight)
-- `<thead>` is `sticky top-0 z-10` relative to the page scroll (`main`), with a
-  solid background + a bottom hairline so column names stay visible while
-  scrolling rows. (`<thead>` already has `sticky top-0`; today it sticks inside
-  the nested scroll div — after removing that div it must stick to `main`.)
-- **Constraint:** `position: sticky` is disabled by an ancestor with
-  `overflow: hidden/clip/auto`. The `.table-surface` card uses `overflow-hidden`
-  for rounded corners, which sits between `<thead>` and `main`. The
-  implementation must preserve the rounded card while letting the sticky work —
-  e.g. drop the clip and round the first/last header cells, or clip only the
-  x-axis. (Exact CSS technique decided in the plan.)
-- No manual `top` offset needed: the app topbar is fixed **outside** `main`, so
-  `top-0` sticks just beneath it.
-- The page title + Filter/Views toolbar **scroll away naturally** (not sticky).
+### 2. Wide-table horizontal scroll (no sticky header)
+- **No sticky `<thead>`.** During planning we confirmed a hard CSS conflict:
+  wide tables need horizontal scroll (`overflow-x: auto`), which per spec
+  promotes the container to a y-scroll context too — making a *page-relative*
+  `sticky` header impossible without reintroducing a bounded-height inner frame
+  (the very thing we're removing). GitHub / Stripe lists scroll their headers
+  with content; we follow that.
+- Wide tables (e.g. posts, transactions, `min-w-[800px]`) scroll **horizontally**
+  inside their card via an inner `overflow-x-auto` wrapper. The `.table-surface`
+  card keeps its rounded corners (`overflow-hidden` unchanged) — the *inner*
+  wrapper owns the horizontal scroll, so there is no clip-vs-sticky conflict.
+- Vertically the table is natural height; the page (`main`) scrolls. The
+  existing `sticky top-0` class on `<thead>` becomes inert (no bounded scroll
+  parent) and is left as-is — harmless, avoids churn.
+- The page title + Filter/Views toolbar scroll naturally.
 
 ### 3. Density & page size
 - Keep default page size **20** and the **10 / 20 / 50** options (users who want
@@ -60,13 +61,15 @@ no viewport-fraction (`vh`) sizing.
 - `src/components/layouts/AppAdminLayout.tsx` — revert `main` / `.app-container`
   flex-fill.
 - `src/components/organisms/DataTable/{types.ts,index.tsx,TableDesktop.tsx}` —
-  remove `fillHeight`; natural-height body; sticky `<thead>`; fix
-  `.table-surface` overflow so sticky works.
+  remove `fillHeight` (and the now-obsolete `tableClassName`/`maxHeightClassName`
+  height override); table body renders at natural height inside an inner
+  `overflow-x-auto` wrapper (horizontal scroll for wide tables).
 - List pages + their table organisms — remove `fillHeight` and revert flex-fill
   wrappers: **users, admins, roles, reports, posts, news, transactions,
   broker-pending** (page + organism where applicable).
-- `src/styles/globals.css` — `.table-surface` overflow handling if changed
-  there.
+- `src/styles/globals.css` — **no change**; `.table-surface` keeps
+  `overflow-hidden` (rounded corners). Horizontal scroll lives on the inner
+  wrapper, so no sticky conflict.
 
 ## Non-goals
 - Sticky filter/toolbar bar (deferred enhancement).
@@ -79,7 +82,8 @@ no viewport-fraction (`vh`) sizing.
 - On a list page (e.g. Users) at 16:9, the table shows all 20 rows at natural
   height; scrolling the page reveals the rows then pagination at the end — **no
   nested scrollbar inside the table**.
-- Column headers stay visible (sticky) while scrolling rows.
+- Wide tables scroll horizontally inside their card; there is **no nested
+  vertical scrollbar** inside the table.
 - No leftover `fillHeight` prop, no `h-[..vh]` on the table body, no
   `lg:min-h-0 lg:flex-1` fill chain on list pages.
 - `tsc --noEmit`, ESLint, Prettier all clean.

--- a/src/components/features/admins/admins-page.tsx
+++ b/src/components/features/admins/admins-page.tsx
@@ -96,8 +96,8 @@ const AdminManagement = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
-      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div>
+      <div className='space-y-6'>
         <PageHeader
           title={t('title')}
           actions={

--- a/src/components/features/brokers/broker-pending-page.tsx
+++ b/src/components/features/brokers/broker-pending-page.tsx
@@ -207,8 +207,8 @@ const BrokerPendingPage = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
-      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div>
+      <div className='space-y-6'>
         {error && (
           <div className='rounded-2xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive'>
             <div className='flex items-center justify-between gap-3'>

--- a/src/components/features/news/news-page.tsx
+++ b/src/components/features/news/news-page.tsx
@@ -183,13 +183,13 @@ const NewsManagement = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
+    <div>
       {initialLoading ? (
         <div className='flex items-center justify-center h-64'>
           <Loader2 className='h-8 w-8 animate-spin text-primary' />
         </div>
       ) : (
-        <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+        <div className='space-y-6'>
           <div className='flex items-center justify-stretch sm:justify-end'>
             <Button
               onClick={handleCreate}

--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -205,13 +205,13 @@ const PostVerification = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
+    <div>
       {initialLoading ? (
         <div className='flex items-center justify-center h-64'>
           <Loader2 className='h-8 w-8 animate-spin text-primary' />
         </div>
       ) : (
-        <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+        <div className='space-y-6'>
           <AiSchedulerControl />
 
           <PostStats stats={stats} />

--- a/src/components/features/reports/reports-page.tsx
+++ b/src/components/features/reports/reports-page.tsx
@@ -108,8 +108,8 @@ const ViolationReportManagement = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
-      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div>
+      <div className='space-y-6'>
         <PageHeader title={t('title')} />
 
         {/* Stats Cards */}

--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -124,7 +124,6 @@ const RoleManagement = () => {
           }
         />
         <DataTable
-          fillHeight
           data={transformedRoles}
           columns={columns}
           filters={filterConfig}

--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -109,8 +109,8 @@ const RoleManagement = () => {
   ]
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
-      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div>
+      <div className='space-y-6'>
         <PageHeader
           title={t('title')}
           actions={

--- a/src/components/features/transactions/transactions-page.tsx
+++ b/src/components/features/transactions/transactions-page.tsx
@@ -49,7 +49,7 @@ export const TransactionsPage = () => {
   }
 
   return (
-    <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div className='space-y-6'>
       <PageHeader title={t('title')} />
 
       <TransactionStatisticsCards statistics={statistics} />

--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -146,8 +146,8 @@ const UserManagement = () => {
   }
 
   return (
-    <div className='flex flex-col lg:min-h-0 lg:flex-1'>
-      <div className='flex flex-col gap-6 lg:min-h-0 lg:flex-1'>
+    <div>
+      <div className='space-y-6'>
         <PageHeader
           title={t('title')}
           actions={

--- a/src/components/layouts/AppAdminLayout.tsx
+++ b/src/components/layouts/AppAdminLayout.tsx
@@ -105,10 +105,8 @@ const AppAdminLayout: React.FC<AppAdminLayoutProps> = ({
         />
 
         <div className='flex-1 overflow-hidden'>
-          <main className='flex h-full w-full flex-col overflow-y-auto'>
-            <div className='app-container flex flex-col lg:min-h-0 lg:flex-1'>
-              {children}
-            </div>
+          <main className='h-full w-full overflow-y-auto'>
+            <div className='app-container'>{children}</div>
           </main>
         </div>
       </div>

--- a/src/components/organisms/DataTable/TableDesktop.tsx
+++ b/src/components/organisms/DataTable/TableDesktop.tsx
@@ -66,8 +66,6 @@ export function TableDesktop<T = any>({
   selectedRows = [],
   onRowSelect,
   onSelectAll,
-  maxHeightClassName,
-  fillHeight,
 }: TableDesktopProps<T>) {
   const t = useTranslations('dataTable')
   const getValue = (row: T, column: Column<T>) => {
@@ -98,22 +96,8 @@ export function TableDesktop<T = any>({
   }
 
   return (
-    <div
-      className={
-        fillHeight
-          ? 'table-surface hidden lg:flex lg:min-h-0 lg:flex-1 lg:flex-col'
-          : 'table-surface hidden lg:block'
-      }
-    >
-      <div
-        className={
-          fillHeight
-            ? 'min-h-0 flex-1 overflow-y-auto'
-            : `overflow-y-auto ${
-                maxHeightClassName || 'h-[50vh] xl:h-[56vh] 2xl:h-[60vh]'
-              }`
-        }
-      >
+    <div className='table-surface hidden lg:block'>
+      <div className='overflow-x-auto'>
         <table className='w-full min-w-[800px] border-separate border-spacing-0'>
           <thead className='sticky top-0 z-10 bg-card/95 backdrop-blur supports-[backdrop-filter]:bg-card/80'>
             <tr>

--- a/src/components/organisms/DataTable/index.tsx
+++ b/src/components/organisms/DataTable/index.tsx
@@ -20,8 +20,6 @@ function DataTableContent<T = any>({
   onSelectionChange,
   filterMode = 'frontend',
   itemsPerPageOptions,
-  tableClassName,
-  fillHeight = false,
 }: Omit<DataTableProps<T>, 'data'>) {
   const {
     paginatedData,
@@ -100,11 +98,7 @@ function DataTableContent<T = any>({
   }, [selectedRows, selectable, onSelectionChange])
 
   return (
-    <div
-      className={
-        fillHeight ? 'flex flex-col gap-4 lg:min-h-0 lg:flex-1' : 'space-y-4'
-      }
-    >
+    <div className='space-y-4'>
       {/* Filters + Views (grouped on the left) */}
       {(filters && filters.length > 0) || columns.length > 0 ? (
         <div className='flex flex-wrap items-center gap-2'>
@@ -151,8 +145,6 @@ function DataTableContent<T = any>({
             selectedRows={selectedRows}
             onRowSelect={toggleRowSelection}
             onSelectAll={toggleAllRows}
-            maxHeightClassName={tableClassName}
-            fillHeight={fillHeight}
           />
 
           {/* Mobile Cards */}

--- a/src/components/organisms/DataTable/types.ts
+++ b/src/components/organisms/DataTable/types.ts
@@ -115,15 +115,6 @@ export interface DataTableProps<T = Record<string, unknown>> {
 
   // Styling
   className?: string
-  tableClassName?: string
-  /**
-   * Fill the available vertical space (flex) instead of using a fixed
-   * viewport-fraction height, so the table body scrolls internally and the
-   * pagination pins to the bottom. Requires the ancestor chain up to the
-   * layout to be a full-height flex column. Fill only engages at `lg`+;
-   * mobile keeps its natural card flow. Default: false (fixed height).
-   */
-  fillHeight?: boolean
 
   // Key extractor
   getRowKey?: (row: T, index: number) => string | number
@@ -178,8 +169,6 @@ export interface TableDesktopProps<T = Record<string, unknown>> {
   selectedRows?: T[]
   onRowSelect?: (row: T) => void
   onSelectAll?: () => void
-  maxHeightClassName?: string
-  fillHeight?: boolean
 }
 
 export interface TableMobileProps<T = Record<string, unknown>> {

--- a/src/components/organisms/admins/AdminTable.tsx
+++ b/src/components/organisms/admins/AdminTable.tsx
@@ -180,7 +180,6 @@ export const AdminTable: React.FC<AdminTableProps> = ({
 
   return (
     <DataTable
-      fillHeight
       data={transformedAdmins}
       columns={columns}
       filters={filterConfig}

--- a/src/components/organisms/brokers/BrokerPendingTable.tsx
+++ b/src/components/organisms/brokers/BrokerPendingTable.tsx
@@ -99,7 +99,6 @@ export const BrokerPendingTable: React.FC<BrokerPendingTableProps> = ({
 
   return (
     <DataTable
-      fillHeight
       data={data}
       columns={columns}
       filterMode='api'

--- a/src/components/organisms/news/NewsTable.tsx
+++ b/src/components/organisms/news/NewsTable.tsx
@@ -247,7 +247,6 @@ export const NewsTable: React.FC<NewsTableProps> = ({
 
   return (
     <DataTable
-      fillHeight
       filterMode='api'
       data={data}
       columns={columns}

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -316,7 +316,6 @@ export const PostTable: React.FC<PostTableProps> = ({
 
   return (
     <DataTable
-      fillHeight
       data={data}
       columns={columns}
       filters={filters}

--- a/src/components/organisms/reports/ReportTable.tsx
+++ b/src/components/organisms/reports/ReportTable.tsx
@@ -168,7 +168,5 @@ export const ReportTable: React.FC<ReportTableProps> = ({
     },
   ]
 
-  return (
-    <DataTable fillHeight columns={columns} data={data} loading={loading} />
-  )
+  return <DataTable columns={columns} data={data} loading={loading} />
 }

--- a/src/components/organisms/transactions/AdminTransactionTable.tsx
+++ b/src/components/organisms/transactions/AdminTransactionTable.tsx
@@ -213,7 +213,6 @@ export const AdminTransactionTable = ({
 
   return (
     <DataTable<AdminTransaction>
-      fillHeight
       data={transactions}
       columns={columns}
       filters={filterConfig}

--- a/src/components/organisms/users/UserTable.tsx
+++ b/src/components/organisms/users/UserTable.tsx
@@ -140,7 +140,6 @@ export const UserTable: React.FC<UserTableProps> = ({
       data={transformedUsers}
       columns={columns}
       filters={filterConfig}
-      fillHeight
       filterMode='api'
       filterValues={filterValues}
       onFilterChange={onFilterChange}


### PR DESCRIPTION
## Summary
Replaces the `fillHeight` fixed-viewport internal-scroll model on admin list pages with **document-scroll** (Stripe/GitHub style): the page scrolls, the table renders at natural height showing all rows of the current page, and wide tables scroll horizontally inside their card. This reverses the earlier fill-height approach after reconsidering the UX — the fixed 1-screen frame limited how much data was visible.

Design + rationale: `docs/superpowers/specs/2026-07-11-admin-table-document-scroll-design.md`
Plan: `docs/superpowers/plans/2026-07-11-admin-table-document-scroll.md`

## Changes
- **Layout** — `main` / `.app-container` revert to a plain block document-scroll container (drop the `flex flex-col` + `lg:min-h-0 lg:flex-1` fill chain).
- **DataTable** — remove the `fillHeight` prop (and the now-obsolete `tableClassName`/`maxHeightClassName` height override). The desktop table body renders at **natural height** inside an inner `overflow-x-auto` wrapper (horizontal scroll for wide tables); no vertical `vh` height, no nested vertical scrollbar. Net −38 lines in the core.
- **List pages + table organisms** — drop `fillHeight` and revert the `lg:min-h-0 lg:flex-1` wrappers to plain `space-y-6` flow: users, admins, roles, reports, posts, news, transactions, broker-pending.

## No sticky header — why
Planning surfaced a hard CSS conflict: a horizontally-scrollable table (`overflow-x: auto`) also becomes a vertical scroll context, so a *page-relative* `sticky` header is impossible without reintroducing a bounded-height inner frame (the thing we're removing). Like GitHub/Stripe lists, headers scroll with content. The existing `sticky top-0` class on `<thead>` is left inert (harmless).

## Verification
- `tsc --noEmit`: **0 errors** project-wide.
- ESLint on `src`: **clean**.
- No `fillHeight` / table-body `vh` height anywhere.
- Dev server boots and serves `/`, `/login`, `/management/users` with **200** and no compile errors.
- ⚠️ Visual acceptance (document-scroll + horizontal scroll look/feel) still needs a **logged-in** session — the table routes are auth-gated, so it couldn't be fully rendered here. Please eyeball a list page (e.g. Users) and a wide one (Transactions/Posts) after checkout.

## Not included (unchanged)
Sticky filter bar (deferred), premium/config tables, mobile card view, pagination component & page-size options.