### PR TITLE
fix: merge acknowledge into dismiss on report review, recolor green

### DIFF
--- a/src/components/organisms/reports/ReportReviewModal.tsx
+++ b/src/components/organisms/reports/ReportReviewModal.tsx
@@ -134,31 +134,6 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
     }
   }
 
-  const handleAcknowledge = async () => {
-    if (!report) return
-
-    if (!actionReason.trim()) {
-      toast.warning(t('toasts.adminNotesRequired'))
-      return
-    }
-
-    try {
-      setActionLoading(true)
-      await ListingService.resolveReport(report.reportId, {
-        status: 'RESOLVED',
-        adminNotes: actionReason,
-      })
-      toast.success(t('toasts.resolveSuccess'))
-      onOpenChange(false)
-      onActionComplete()
-    } catch (e) {
-      console.error(e)
-      toast.error(t('toasts.resolveError'))
-    } finally {
-      setActionLoading(false)
-    }
-  }
-
   const handleRemoveListing = async () => {
     if (!report) return
 
@@ -649,19 +624,6 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                 <Button
                   onClick={handleDismiss}
                   disabled={actionLoading}
-                  variant='outline'
-                  className='border-destructive/30 text-destructive hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive text-sm'
-                >
-                  {actionLoading ? (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  ) : (
-                    <XCircle className='mr-2 h-4 w-4' />
-                  )}
-                  {t('review.dismiss')}
-                </Button>
-                <Button
-                  onClick={handleAcknowledge}
-                  disabled={actionLoading}
                   className='bg-success text-success-foreground hover:bg-success/90 text-sm'
                 >
                   {actionLoading ? (
@@ -669,7 +631,7 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                   ) : (
                     <CheckCircle className='mr-2 h-4 w-4' />
                   )}
-                  {t('review.acknowledge')}
+                  {t('review.dismiss')}
                 </Button>
               </div>
             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1937,9 +1937,6 @@
     },
     "toasts": {
       "loadListingError": "Failed to load listing details",
-      "adminNotesRequired": "Please provide admin notes for resolution",
-      "resolveSuccess": "Report has been resolved successfully",
-      "resolveError": "Failed to resolve report. Please try again.",
       "dismissNoteRequired": "Please provide a reason for dismissal",
       "dismissSuccess": "Report has been dismissed",
       "dismissError": "Failed to dismiss report. Please try again.",
@@ -1967,7 +1964,6 @@
       "reportedAt": "Reported At",
       "additionalFeedback": "Additional Feedback",
       "currentStatus": "Current Status",
-      "acknowledge": "Acknowledge Report",
       "requestRevision": "Request Revision",
       "removeListing": "Suspend Listing",
       "dismiss": "Dismiss Report",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1901,9 +1901,6 @@
     },
     "toasts": {
       "loadListingError": "Không thể tải thông tin tin đăng",
-      "adminNotesRequired": "Vui lòng nhập ghi chú xử lý",
-      "resolveSuccess": "Báo cáo đã được giải quyết thành công",
-      "resolveError": "Không thể giải quyết báo cáo. Vui lòng thử lại.",
       "dismissNoteRequired": "Vui lòng cung cấp lý do bác bỏ",
       "dismissSuccess": "Báo cáo đã được bác bỏ",
       "dismissError": "Không thể bác bỏ báo cáo. Vui lòng thử lại.",
@@ -1931,7 +1928,6 @@
       "reportedAt": "Thời Gian Báo Cáo",
       "additionalFeedback": "Phản Hồi Bổ Sung",
       "currentStatus": "Trạng Thái Hiện Tại",
-      "acknowledge": "Ghi Nhận",
       "requestRevision": "Yêu Cầu Sửa Đổi",
       "removeListing": "Đình Chỉ Tin Đăng",
       "dismiss": "Bỏ Qua",


### PR DESCRIPTION
Ghi Nhận and Bỏ Qua had identical effect on the listing (both leave it untouched) and only differed in the report's own status, which wasn't a distinction worth two buttons for. Drop Ghi Nhận and restyle Bỏ Qua as the solid green/CheckCircle "no action needed" outcome.