### PR TITLE
refactor(admin): remove page titles, move action buttons into the table toolbar

### DIFF
--- a/src/components/features/admins/admins-page.tsx
+++ b/src/components/features/admins/admins-page.tsx
@@ -10,7 +10,6 @@ import { AdminTable } from '@/components/organisms/admins/AdminTable'
 import { AdminCreateDialog } from '@/components/organisms/admins/AdminCreateDialog'
 import { AdminEditDialog } from '@/components/organisms/admins/AdminEditDialog'
 import { AdminDeleteDialog } from '@/components/organisms/admins/AdminDeleteDialog'
-import { PageHeader } from '@/components/molecules/pageHeader'
 
 const AdminManagement = () => {
   const t = useTranslations('admin.admins')
@@ -98,19 +97,6 @@ const AdminManagement = () => {
   return (
     <div>
       <div className='space-y-6'>
-        <PageHeader
-          title={t('title')}
-          actions={
-            <Button
-              className='w-full sm:w-auto'
-              onClick={() => setCreateDialogOpen(true)}
-            >
-              <Plus className='h-4 w-4' />
-              {t('createNewAdmin')}
-            </Button>
-          }
-        />
-
         {/* DataTable Component */}
         <AdminTable
           admins={admins}
@@ -120,6 +106,12 @@ const AdminManagement = () => {
           onFilterChange={handleFilterChange}
           onEdit={setEditingAdmin}
           onDelete={setShowDelete}
+          toolbarActions={
+            <Button size='sm' onClick={() => setCreateDialogOpen(true)}>
+              <Plus className='h-4 w-4' />
+              {t('createNewAdmin')}
+            </Button>
+          }
         />
 
         {/* Modals */}

--- a/src/components/features/news/news-page.tsx
+++ b/src/components/features/news/news-page.tsx
@@ -190,16 +190,6 @@ const NewsManagement = () => {
         </div>
       ) : (
         <div className='space-y-6'>
-          <div className='flex items-center justify-stretch sm:justify-end'>
-            <Button
-              onClick={handleCreate}
-              className='w-full sm:w-auto flex items-center justify-center gap-2'
-            >
-              <Plus className='h-4 w-4' />
-              {t('createButton')}
-            </Button>
-          </div>
-
           {/* Hidden by request */}
           {false && <NewsStats stats={stats} />}
 
@@ -212,6 +202,12 @@ const NewsManagement = () => {
             onPreview={handlePreview}
             onEdit={handleEdit}
             onDelete={handleDeleteClick}
+            toolbarActions={
+              <Button size='sm' onClick={handleCreate}>
+                <Plus className='h-4 w-4' />
+                {t('createButton')}
+              </Button>
+            }
           />
 
           <NewsPreviewModal

--- a/src/components/features/premium/premium-section-page.tsx
+++ b/src/components/features/premium/premium-section-page.tsx
@@ -18,7 +18,6 @@ import { ListingTypeTable } from '@/components/organisms/premium/ListingTypeTabl
 import { EditMembershipDialog } from '@/components/organisms/premium/EditMembershipDialog'
 import { DeleteMembershipDialog } from '@/components/organisms/premium/DeleteMembershipDialog'
 import { ViewMembershipDialog } from '@/components/organisms/premium/ViewMembershipDialog'
-import { PageHeader } from '@/components/molecules/pageHeader'
 
 export type PremiumSection = 'overview' | 'membership' | 'listing-types'
 
@@ -225,15 +224,12 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
     <div className='space-y-6'>
       {section === 'overview' && (
         <>
-          <PageHeader title={t('title')} />
           <PremiumStats stats={stats} />
         </>
       )}
 
       {section === 'membership' && (
         <>
-          <PageHeader title={t('title')} />
-
           <MembershipTable
             memberships={displayMemberships}
             loading={membershipsLoading}
@@ -247,7 +243,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
 
       {section === 'listing-types' && (
         <>
-          <PageHeader title={t('title')} />
           <ListingTypeTable tiers={apiVIPTiers} loading={vipTiersLoading} />
         </>
       )}

--- a/src/components/features/reports/reports-page.tsx
+++ b/src/components/features/reports/reports-page.tsx
@@ -8,7 +8,6 @@ import { ListingService } from '@/api/services/listing.service'
 import { ReportStats } from '@/components/organisms/reports/ReportStats'
 import { ReportTable } from '@/components/organisms/reports/ReportTable'
 import { ReportReviewModal } from '@/components/organisms/reports/ReportReviewModal'
-import { PageHeader } from '@/components/molecules/pageHeader'
 
 const ViolationReportManagement = () => {
   const t = useTranslations('reports')
@@ -110,8 +109,6 @@ const ViolationReportManagement = () => {
   return (
     <div>
       <div className='space-y-6'>
-        <PageHeader title={t('title')} />
-
         {/* Stats Cards */}
         <ReportStats stats={stats} />
 

--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -11,7 +11,6 @@ import { getRoles } from '@/api/services/role.service'
 import { Role } from '@/api/types/role.type'
 import { useTranslations } from 'next-intl'
 import { Plus, Pencil, Trash2 } from 'lucide-react'
-import { PageHeader } from '@/components/molecules/pageHeader'
 import { RoleCreateDialog } from '@/components/organisms/roles/RoleCreateDialog'
 import { RoleEditDialog } from '@/components/organisms/roles/RoleEditDialog'
 import { RoleDeleteDialog } from '@/components/organisms/roles/RoleDeleteDialog'
@@ -111,22 +110,16 @@ const RoleManagement = () => {
   return (
     <div>
       <div className='space-y-6'>
-        <PageHeader
-          title={t('title')}
-          actions={
-            <Button
-              className='w-full sm:w-auto'
-              onClick={() => setShowCreate(true)}
-            >
-              <Plus className='h-4 w-4' />
-              {t('createNewRole')}
-            </Button>
-          }
-        />
         <DataTable
           data={transformedRoles}
           columns={columns}
           filters={filterConfig}
+          toolbarActions={
+            <Button size='sm' onClick={() => setShowCreate(true)}>
+              <Plus className='h-4 w-4' />
+              {t('createNewRole')}
+            </Button>
+          }
           filterMode='api'
           filterValues={filterValues}
           onFilterChange={handleFilterChange}

--- a/src/components/features/transactions/transactions-dashboard-page.tsx
+++ b/src/components/features/transactions/transactions-dashboard-page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react'
 import { useTranslations } from 'next-intl'
-import { PageHeader } from '@/components/molecules/pageHeader'
 import { TransactionStatisticsCards } from '@/components/organisms/transactions/TransactionStatisticsCards'
 import { RevenueChart } from '@/components/organisms/transactions/RevenueChart'
 import {
@@ -28,8 +27,6 @@ export const TransactionsDashboardPage = () => {
 
   return (
     <div className='space-y-6'>
-      <PageHeader title={t('dashboard.title')} />
-
       <div className='flex gap-2'>
         {(['week', 'month', 'quarter'] as const).map((range) => (
           <button

--- a/src/components/features/transactions/transactions-page.tsx
+++ b/src/components/features/transactions/transactions-page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { Download } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
-import { PageHeader } from '@/components/molecules/pageHeader'
 import { AdminTransactionTable } from '@/components/organisms/transactions/AdminTransactionTable'
 import { TransactionStatisticsCards } from '@/components/organisms/transactions/TransactionStatisticsCards'
 import { TransactionService } from '@/api/services/transaction.service'
@@ -50,16 +49,7 @@ export const TransactionsPage = () => {
 
   return (
     <div className='space-y-6'>
-      <PageHeader title={t('title')} />
-
       <TransactionStatisticsCards statistics={statistics} />
-
-      <div className='flex justify-end'>
-        <Button variant='outline' size='sm' onClick={handleExport}>
-          <Download className='h-4 w-4' />
-          {t('filters.export')}
-        </Button>
-      </div>
 
       <AdminTransactionTable
         transactions={transactionsList?.data || []}
@@ -68,6 +58,12 @@ export const TransactionsPage = () => {
         onFiltersChange={handleFiltersChange}
         isLoading={isLoadingTransactions}
         onViewDetails={handleViewDetails}
+        toolbarActions={
+          <Button variant='outline' size='sm' onClick={handleExport}>
+            <Download className='h-4 w-4' />
+            {t('filters.export')}
+          </Button>
+        }
       />
     </div>
   )

--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -13,7 +13,6 @@ import { UserCreateDialog } from '@/components/organisms/users/UserCreateDialog'
 import { UserEditDialog } from '@/components/organisms/users/UserEditDialog'
 import { UserDeleteDialog } from '@/components/organisms/users/UserDeleteDialog'
 import { UserClearMembershipDialog } from '@/components/organisms/users/UserClearMembershipDialog'
-import { PageHeader } from '@/components/molecules/pageHeader'
 import { ConfirmDialog } from '@/components/molecules/confirmDialog'
 
 const UserManagement = () => {
@@ -148,19 +147,6 @@ const UserManagement = () => {
   return (
     <div>
       <div className='space-y-6'>
-        <PageHeader
-          title={t('title')}
-          actions={
-            <Button
-              className='w-full sm:w-auto'
-              onClick={() => setShowCreate(true)}
-            >
-              <Plus className='h-4 w-4' />
-              {t('create.button')}
-            </Button>
-          }
-        />
-
         {/* User Table Component */}
         <UserTable
           users={users}
@@ -172,6 +158,12 @@ const UserManagement = () => {
           onDelete={setShowDelete}
           onRemoveBroker={(user) => setRemoveBrokerUser(user)}
           onClearMembership={setShowClearMembership}
+          toolbarActions={
+            <Button size='sm' onClick={() => setShowCreate(true)}>
+              <Plus className='h-4 w-4' />
+              {t('create.button')}
+            </Button>
+          }
         />
       </div>
 

--- a/src/components/organisms/DataTable/index.tsx
+++ b/src/components/organisms/DataTable/index.tsx
@@ -20,6 +20,7 @@ function DataTableContent<T = any>({
   onSelectionChange,
   filterMode = 'frontend',
   itemsPerPageOptions,
+  toolbarActions,
 }: Omit<DataTableProps<T>, 'data'>) {
   const {
     paginatedData,
@@ -99,8 +100,10 @@ function DataTableContent<T = any>({
 
   return (
     <div className='space-y-4'>
-      {/* Filters + Views (grouped on the left) */}
-      {(filters && filters.length > 0) || columns.length > 0 ? (
+      {/* Toolbar: filters + views on the left, actions on the right */}
+      {(filters && filters.length > 0) ||
+      columns.length > 0 ||
+      toolbarActions ? (
         <div className='flex flex-wrap items-center gap-2'>
           {filters && filters.length > 0 && (
             <TableFilters
@@ -119,6 +122,11 @@ function DataTableContent<T = any>({
             onShowAll={showAllColumns}
             onReset={resetColumns}
           />
+          {toolbarActions && (
+            <div className='ml-auto flex items-center gap-2'>
+              {toolbarActions}
+            </div>
+          )}
         </div>
       ) : null}
 

--- a/src/components/organisms/DataTable/types.ts
+++ b/src/components/organisms/DataTable/types.ts
@@ -113,6 +113,9 @@ export interface DataTableProps<T = Record<string, unknown>> {
   selectable?: boolean // Checkbox để chọn nhiều rows
   onSelectionChange?: (selectedRows: T[]) => void
 
+  /** Right-aligned content in the filter/views toolbar row (e.g. a "Create" button). */
+  toolbarActions?: ReactNode
+
   // Styling
   className?: string
 

--- a/src/components/organisms/admins/AdminTable.tsx
+++ b/src/components/organisms/admins/AdminTable.tsx
@@ -39,6 +39,7 @@ interface AdminTableProps {
   onFilterChange: (newFilters: Record<string, unknown>) => void
   onEdit: (admin: AdminProfile) => void
   onDelete: (admin: AdminProfile) => void
+  toolbarActions?: React.ReactNode
 }
 
 export const AdminTable: React.FC<AdminTableProps> = ({
@@ -49,6 +50,7 @@ export const AdminTable: React.FC<AdminTableProps> = ({
   onFilterChange,
   onEdit,
   onDelete,
+  toolbarActions,
 }) => {
   const t = useTranslations('admin.admins')
   const roleLabels: Record<AdminRole, string> = {
@@ -183,6 +185,7 @@ export const AdminTable: React.FC<AdminTableProps> = ({
       data={transformedAdmins}
       columns={columns}
       filters={filterConfig}
+      toolbarActions={toolbarActions}
       filterMode='api'
       filterValues={filterValues}
       onFilterChange={onFilterChange}

--- a/src/components/organisms/news/NewsTable.tsx
+++ b/src/components/organisms/news/NewsTable.tsx
@@ -26,6 +26,7 @@ interface NewsTableProps {
   onPreview: (news: NewsSummaryResponse) => void
   onEdit: (news: NewsSummaryResponse) => void
   onDelete: (news: NewsSummaryResponse) => void
+  toolbarActions?: React.ReactNode
 }
 
 const getStatusColor = (status: NewsStatus): string => {
@@ -77,6 +78,7 @@ export const NewsTable: React.FC<NewsTableProps> = ({
   onPreview,
   onEdit,
   onDelete,
+  toolbarActions,
 }) => {
   const t = useTranslations('news')
 
@@ -251,6 +253,7 @@ export const NewsTable: React.FC<NewsTableProps> = ({
       data={data}
       columns={columns}
       filters={filterConfig}
+      toolbarActions={toolbarActions}
       filterValues={filterValues}
       onFilterChange={onFilterChange}
       totalItems={totalItems}

--- a/src/components/organisms/transactions/AdminTransactionTable.tsx
+++ b/src/components/organisms/transactions/AdminTransactionTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { ReactNode } from 'react'
 import { useTranslations } from 'next-intl'
 import { Eye } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
@@ -29,6 +30,7 @@ interface AdminTransactionTableProps {
   onFiltersChange: (filters: AdminTransactionFilters) => void
   isLoading?: boolean
   onViewDetails: (transactionId: string) => void
+  toolbarActions?: ReactNode
 }
 
 const STATUS_BADGE_CLASS: Record<PaymentStatus, string> = {
@@ -51,6 +53,7 @@ export const AdminTransactionTable = ({
   onFiltersChange,
   isLoading,
   onViewDetails,
+  toolbarActions,
 }: AdminTransactionTableProps) => {
   const t = useTranslations('transactions')
   const pageSize = filters.size ?? 20
@@ -214,6 +217,7 @@ export const AdminTransactionTable = ({
   return (
     <DataTable<AdminTransaction>
       data={transactions}
+      toolbarActions={toolbarActions}
       columns={columns}
       filters={filterConfig}
       filterMode='api'

--- a/src/components/organisms/users/UserTable.tsx
+++ b/src/components/organisms/users/UserTable.tsx
@@ -23,6 +23,7 @@ interface UserTableProps {
   onDelete: (user: UserProfile) => void
   onRemoveBroker: (user: UserProfile) => void
   onClearMembership: (user: UserProfile) => void
+  toolbarActions?: React.ReactNode
 }
 
 export const UserTable: React.FC<UserTableProps> = ({
@@ -35,6 +36,7 @@ export const UserTable: React.FC<UserTableProps> = ({
   onDelete,
   onRemoveBroker,
   onClearMembership,
+  toolbarActions,
 }) => {
   const t = useTranslations('admin.users')
 
@@ -140,6 +142,7 @@ export const UserTable: React.FC<UserTableProps> = ({
       data={transformedUsers}
       columns={columns}
       filters={filterConfig}
+      toolbarActions={toolbarActions}
       filterMode='api'
       filterValues={filterValues}
       onFilterChange={onFilterChange}


### PR DESCRIPTION
## Summary
Removes the "Quản Lý ..." page title from every admin page and puts each page's primary action (Create / Export) on the **same row** as the Bộ lọc / Hiển thị buttons (filters left, action right) — instead of floating on its own row above the toolbar. The breadcrumb (Trang chủ › Quản trị › …) already shows where you are, so the H1 was redundant.

Follows up the document-scroll PR (#74). Same root cause the user spotted: the action button lived outside `DataTable` (in `PageHeader` or a standalone `justify-end` div), so it couldn't share the toolbar row.

## Changes
- **DataTable** — new optional `toolbarActions` prop, rendered right-aligned (`ml-auto`) in the filter/views toolbar row.
- **UserTable / AdminTable / NewsTable / AdminTransactionTable** — forward `toolbarActions` to `DataTable`.
- **users / admins / roles** — `PageHeader` removed; the Create button moves into `toolbarActions`.
- **news** — the standalone Create row removed; Create moves into `toolbarActions`.
- **transactions** — `PageHeader` + the standalone Export row removed; Export moves into `toolbarActions`.
- **reports / premium (×3) / transactions-dashboard** — title-only `PageHeader` removed.
- The `PageHeader` molecule is now unused (kept in the tree for potential reuse; happy to delete if you prefer).

## Verification
- `tsc --noEmit`: **0 errors** project-wide.
- ESLint: **clean** on all changed files (no orphaned imports).
- Dev server serves `/management/{users,admins,roles,transactions}`, `/content/news`, `/moderation/reports` with **200**, no compile errors.
- ⚠️ Visual (button height/alignment in the toolbar row) best eyeballed logged-in — the action button uses `size='sm'` to match the Bộ lọc/Hiển thị buttons.