### PR TITLE
feat(admin): redesign sidebar for clearer hierarchy & scanning

### DIFF
--- a/docs/superpowers/specs/2026-07-11-admin-sidebar-redesign-design.md
+++ b/docs/superpowers/specs/2026-07-11-admin-sidebar-redesign-design.md
@@ -1,0 +1,55 @@
+# Admin sidebar visual redesign
+
+**Date:** 2026-07-11
+**Status:** Approved (design)
+
+## Goal
+Redesign the Admin Console sidebar for a clearer visual hierarchy and faster
+scanning — **without changing menu structure, routes, labels, i18n, or the
+collapse / language features.** Visual-only, one component.
+
+## Non-goals
+- **No label renames.** Original labels stay (duplicate names like "Người
+  dùng" / "Tin đăng" / "Báo cáo" remain — the group header + hierarchy give
+  context). `navigation.ts` is untouched. *(User dropped the rename idea:
+  prefixes felt cluttered.)*
+- No route / structure / i18n changes.
+- Collapsed (icon-rail) behavior, the always-open default, and the collapse
+  toggle stay exactly as today.
+
+## Design — expanded mode
+1. **Group header = plain section label.** Drop the group icon in **expanded**
+   mode so a group reads as an uppercase text label (icon-vs-no-icon instantly
+   separates Group from Item). Keep `text-[11px] font-semibold uppercase
+   tracking-wider`, muted color. Bigger gap **above** each group (`mt-6`, first
+   group none) so each group is its own block. Chevron stays (collapse), quiet
+   on the right. **The group icon is still rendered in the collapsed icon rail**
+   (that mode is unchanged).
+2. **Active-group highlight.** When a child is active, its group header turns
+   `text-sidebar-foreground font-bold` (from muted) so you see which area
+   you're in.
+3. **Menu items — clear indent + scannable.** Indented deeper than the group
+   label; height ~`py-2.5`, `gap-2.5` icon↔text, `space-y-1` between items.
+4. **Active item — multi-signal.** `bg-sidebar-primary/12` +
+   `text-sidebar-primary` + icon in primary + `font-semibold` + a left accent
+   bar `w-1 rounded-full` (near full item height; thicker than today's `w-0.5`).
+5. **Inactive item.** `text-sidebar-foreground/70`, icon `text-muted-foreground`,
+   hover `bg-sidebar-accent`.
+
+## Scope
+- `src/components/organisms/adminSidebar.tsx` only:
+  - `SidebarItem`: height / gap / active styling + thicker accent bar +
+    `font-semibold` when active + primary icon when active.
+  - `SidebarSection`: expanded header = text label only (no icon), bigger top
+    gap, `isActiveGroup` prop → bold/foreground when active; keep the group icon
+    for collapsed mode and the chevron for the toggle.
+  - `AdminSidebar`: pass `isActiveGroup={activeGroupKey === group.key}` to each
+    section (activeGroupKey already computed).
+
+## Acceptance
+- Expanded: groups clearly distinct from items (text label vs icon+label),
+  visible indent, generous inter-group spacing.
+- Active item stands out (bg + text + icon + weight + accent bar); its group
+  header is highlighted.
+- Collapse toggle, language switcher, routes, and all labels unchanged.
+- `tsc --noEmit`, ESLint, Prettier clean; dev server boots and serves.

--- a/src/components/organisms/adminSidebar.tsx
+++ b/src/components/organisms/adminSidebar.tsx
@@ -54,22 +54,22 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
     <div
       onClick={disabled ? undefined : onClick}
       className={cn(
-        'relative mx-2 flex items-center rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-        collapsed ? 'justify-center' : 'gap-3',
+        'relative mx-2 flex items-center rounded-lg px-3 py-2.5 text-sm transition-colors',
+        collapsed ? 'justify-center' : 'gap-2.5',
         disabled
-          ? 'cursor-not-allowed text-muted-foreground/60'
+          ? 'cursor-not-allowed font-medium text-muted-foreground/60'
           : 'cursor-pointer',
         !disabled &&
           (isActive
-            ? 'bg-sidebar-primary/10 text-sidebar-primary'
-            : 'text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'),
+            ? 'bg-sidebar-primary/12 font-semibold text-sidebar-primary'
+            : 'font-medium text-sidebar-foreground/70 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground'),
       )}
       title={collapsed ? label : undefined}
     >
       {!disabled && isActive && !collapsed && (
         <span
           aria-hidden
-          className='absolute left-0 top-1/2 h-5 w-0.5 -translate-y-1/2 rounded-full bg-sidebar-primary'
+          className='absolute left-0 top-1/2 h-6 w-1 -translate-y-1/2 rounded-full bg-sidebar-primary'
         />
       )}
       {icon && (
@@ -93,6 +93,7 @@ type SidebarSectionProps = {
   collapsed?: boolean
   open: boolean
   onToggle: () => void
+  isActiveGroup?: boolean
   children: React.ReactNode
 }
 
@@ -102,14 +103,20 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
   collapsed = false,
   open,
   onToggle,
+  isActiveGroup = false,
   children,
 }) => {
   return (
-    <div className='mb-2 last:mb-0'>
+    <div className='mt-6 first:mt-0'>
       <button
         type='button'
         onClick={collapsed ? undefined : onToggle}
-        className='mb-1 flex w-full items-center justify-between rounded-md px-3 py-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-sidebar-foreground'
+        className={cn(
+          'mb-1.5 flex w-full items-center justify-between rounded-md px-2 py-1 text-[11px] uppercase tracking-wider transition-colors',
+          isActiveGroup && !collapsed
+            ? 'font-bold text-sidebar-foreground'
+            : 'font-semibold text-muted-foreground/80 hover:text-sidebar-foreground',
+        )}
         title={collapsed ? title : undefined}
       >
         <span
@@ -118,13 +125,15 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
             collapsed && 'mx-auto',
           )}
         >
-          {icon && <span className='h-4 w-4'>{icon}</span>}
+          {/* Group icon only in the collapsed icon rail; expanded groups are
+              plain text labels so they read as sections, not items. */}
+          {collapsed && icon && <span className='h-4 w-4'>{icon}</span>}
           {!collapsed && <span>{title}</span>}
         </span>
         {!collapsed && (
           <ChevronRight
             className={cn(
-              'h-3.5 w-3.5 transition-transform duration-300 ease-in-out',
+              'h-3.5 w-3.5 shrink-0 text-muted-foreground/60 transition-transform duration-300 ease-in-out',
               open && 'rotate-90',
             )}
           />
@@ -138,7 +147,7 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
             open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0',
           )}
         >
-          <div className='space-y-0.5 overflow-hidden'>{children}</div>
+          <div className='space-y-1 overflow-hidden'>{children}</div>
         </div>
       )}
     </div>
@@ -316,6 +325,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
             collapsed={collapsed}
             open={!!openGroups[group.key]}
             onToggle={() => toggleGroup(group.key)}
+            isActiveGroup={activeGroupKey === group.key}
           >
             {group.items.map((item) => (
               <SidebarItem


### PR DESCRIPTION
## Summary
Redesigns the Admin Console sidebar for a clearer Group→Item hierarchy and faster scanning. **Visual only** — no change to menu structure, routes, labels, i18n, or the collapse / language features. Single component (`adminSidebar.tsx`).

Design: `docs/superpowers/specs/2026-07-11-admin-sidebar-redesign-design.md`

## Changes
- **Group vs Item distinction** — in expanded mode, group headers become plain **uppercase text labels** (no icon), so "label vs icon+label" separates Group from Item at a glance. The group icon is kept for the **collapsed icon rail** (that mode is unchanged).
- **Group spacing** — big top gap (`mt-6`) before each group → every group reads as its own block.
- **Indent** — group header dedented (`px-2`); items stay inset (`mx-2 px-3`) so menu items sit clearly indented under the group label.
- **Active item** — tinted bg (`bg-sidebar-primary/12`) + `text-sidebar-primary` + primary icon + `font-semibold` + a thicker/taller left accent bar (`w-1 h-6 rounded-full`, was `w-0.5 h-5`).
- **Active group** — when a group contains the active item, its header turns `font-bold text-sidebar-foreground` (from muted) so you can see which area you're in.
- **Scan** — taller rows (`py-2.5`), tighter icon↔text gap (`gap-2.5`), more space between items (`space-y-1`).

## Not changed (per request)
- No label renames — kept "Người dùng" / "Tin đăng" / "Báo cáo" as-is (the group header + new hierarchy give context; prefixes felt cluttered).
- Collapse toggle, always-open default, language switcher, routes, i18n — untouched.

## Verification
- `tsc --noEmit`: 0 errors · ESLint: clean · Prettier: formatted.
- Dev server serves `/management/users` (renders `AdminSidebar`) with 200, no errors.
- ⚠️ The sidebar is auth-gated, so I couldn't screenshot it logged-in — please eyeball the spacing/active-state after checkout.