### PR TITLE
fix: switch news editor image upload to presign flow

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -118,6 +118,8 @@ export const PATHS = {
   // Admin media endpoints
   ADMIN_MEDIA: {
     UPLOAD: '/v1/admin/media/upload',
+    UPLOAD_URL: '/v1/admin/media/upload-url',
+    CONFIRM: '/v1/admin/media/:mediaId/confirm',
     LIST: '/v1/admin/media',
     DETAIL: '/v1/admin/media/:mediaId',
     DELETE: '/v1/admin/media/:mediaId',

--- a/src/api/services/admin-media.service.ts
+++ b/src/api/services/admin-media.service.ts
@@ -1,7 +1,11 @@
+import axios from 'axios'
 import { apiRequest } from '@/configs/axios/axiosClient'
 import { ApiResponse } from '@/configs/axios/types'
 import { PATHS } from '@/api/paths'
 import {
+  AdminConfirmUploadRequest,
+  AdminCreateUploadUrlApiResponse,
+  AdminCreateUploadUrlRequest,
   AdminMediaApiResponse,
   AdminMediaListApiResponse,
   AdminMediaListFilter,
@@ -61,6 +65,67 @@ export class AdminMediaService {
         'Content-Type': 'multipart/form-data',
       },
     })
+  }
+
+  static async createUploadUrl(
+    request: AdminCreateUploadUrlRequest,
+  ): Promise<AdminCreateUploadUrlApiResponse> {
+    return apiRequest({
+      method: 'POST',
+      url: PATHS.ADMIN_MEDIA.UPLOAD_URL,
+      data: request,
+    })
+  }
+
+  static async confirmUpload(
+    mediaId: number,
+    request: AdminConfirmUploadRequest,
+  ): Promise<AdminMediaApiResponse> {
+    return apiRequest<AdminMediaResponse>({
+      method: 'POST',
+      url: replacePathParam(PATHS.ADMIN_MEDIA.CONFIRM, 'mediaId', mediaId),
+      data: request,
+    })
+  }
+
+  /**
+   * Upload a file directly to R2 via a presigned URL instead of proxying
+   * the bytes through the backend: request a presigned PUT URL, upload the
+   * file straight to R2, then confirm so the backend flips the media record
+   * to ACTIVE.
+   */
+  static async uploadViaPresign(
+    request: Omit<
+      AdminCreateUploadUrlRequest,
+      'filename' | 'contentType' | 'fileSize'
+    > & {
+      file: File
+    },
+  ): Promise<AdminMediaApiResponse> {
+    const { file, ...rest } = request
+
+    const presignResponse = await AdminMediaService.createUploadUrl({
+      ...rest,
+      filename: file.name,
+      contentType: file.type,
+      fileSize: file.size,
+    })
+
+    if (!presignResponse.success || !presignResponse.data) {
+      return presignResponse as unknown as AdminMediaApiResponse
+    }
+
+    const { mediaId, uploadUrl } = presignResponse.data
+
+    // Raw axios (not the app's client): must skip the Bearer token,
+    // baseURL, and response interceptors, or R2 rejects the signed request.
+    await axios.put(uploadUrl, file, {
+      headers: { 'Content-Type': file.type },
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+    })
+
+    return AdminMediaService.confirmUpload(mediaId, { contentType: file.type })
   }
 
   static async getAllMedia(

--- a/src/api/services/news.service.ts
+++ b/src/api/services/news.service.ts
@@ -42,7 +42,7 @@ const buildQuery = (
 
 export class NewsService {
   static async uploadImage(file: File): Promise<ApiResponse<{ url: string }>> {
-    const response = await AdminMediaService.uploadMedia({
+    const response = await AdminMediaService.uploadViaPresign({
       file,
       mediaType: 'IMAGE',
       title: file.name,

--- a/src/api/types/admin-media.type.ts
+++ b/src/api/types/admin-media.type.ts
@@ -44,5 +44,33 @@ export interface AdminMediaListFilter {
   size?: number
 }
 
+export interface AdminCreateUploadUrlRequest {
+  mediaType: AdminMediaType
+  filename: string
+  contentType: string
+  fileSize: number
+  listingId?: number
+  title?: string
+  description?: string
+  altText?: string
+  isPrimary?: boolean
+  sortOrder?: number
+}
+
+export interface AdminCreateUploadUrlResponse {
+  mediaId: number
+  uploadUrl: string
+  expiresIn: number
+  storageKey: string
+  message: string
+}
+
+export interface AdminConfirmUploadRequest {
+  checksum?: string
+  contentType?: string
+}
+
 export type AdminMediaApiResponse = ApiResponse<AdminMediaResponse>
 export type AdminMediaListApiResponse = ApiResponse<AdminMediaResponse[]>
+export type AdminCreateUploadUrlApiResponse =
+  ApiResponse<AdminCreateUploadUrlResponse>


### PR DESCRIPTION
Admin uploads via multipart to /v1/admin/media/upload were failing with a backend FK constraint error (admin_id stored in a users-only column). Backend now exposes an admin-scoped presign flow; switch the news editor's upload path to match: request a presigned URL, PUT the file straight to R2, then confirm — same pattern already used by the main tenant app's media.service.ts.