### PR TITLE
feat: reported-authors tab + temporary hide/unhide on reports

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -50,6 +50,13 @@ export const PATHS = {
     BROKER_REMOVE: '/v1/admin/users/:userId/broker',
   },
 
+  // Admin reported-authors endpoints (track post authors + block posting)
+  REPORTED_AUTHORS: {
+    LIST: '/v1/admin/reported-authors',
+    REPORTS: '/v1/admin/reported-authors/:userId/reports',
+    POSTING_BLOCK: '/v1/admin/reported-authors/:userId/posting-block',
+  },
+
   // Admin analytics endpoints (formerly /v1/admin/dashboard/*)
   ADMIN_ANALYTICS: {
     REVENUE: '/v1/admin/analytics/revenue',

--- a/src/api/services/listing.service.ts
+++ b/src/api/services/listing.service.ts
@@ -239,6 +239,57 @@ export class ListingService {
   }
 
   /**
+   * Temporarily hide a reported listing from the public (moderation SUSPEND).
+   * Owner is still able to resubmit later — this is not a permanent removal.
+   * PUT /v1/admin/listings/{listingId}/status with decision=SUSPEND
+   *
+   * @param listingId - Listing ID
+   * @param reasonText - Reason for hiding (required by the moderation service)
+   */
+  static async hideListing(
+    listingId: number | string,
+    reasonText: string,
+  ): Promise<
+    ApiResponse<{
+      listingId: number
+      title: string
+      verified: boolean
+      isVerify: boolean
+      userId: string
+      price: number
+      listingType: string
+    }>
+  > {
+    return this.changeListingStatus(listingId, {
+      decision: 'SUSPEND',
+      reasonText,
+      ownerActionRequired: false,
+    })
+  }
+
+  /**
+   * Unhide a previously hidden listing (restore to APPROVED / public).
+   * PUT /v1/admin/listings/{listingId}/status with decision=APPROVE
+   *
+   * @param listingId - Listing ID
+   */
+  static async unhideListing(listingId: number | string): Promise<
+    ApiResponse<{
+      listingId: number
+      title: string
+      verified: boolean
+      isVerify: boolean
+      userId: string
+      price: number
+      listingType: string
+    }>
+  > {
+    return this.changeListingStatus(listingId, {
+      decision: 'APPROVE',
+    })
+  }
+
+  /**
    * Get all listing reports
    * GET /v1/admin/reports
    *

--- a/src/api/services/reported-author.service.ts
+++ b/src/api/services/reported-author.service.ts
@@ -1,0 +1,59 @@
+import { apiRequest } from '@/configs/axios/axiosClient'
+import { PATHS } from '@/api/paths'
+import { ApiResponse } from '@/configs/axios/types'
+import { ListingReport } from '@/api/types/listing-report.type'
+import {
+  ReportedAuthor,
+  ReportedAuthorListResponse,
+  PostingBlockRequest,
+} from '@/api/types/reported-author.type'
+
+/**
+ * Reported-authors service for the Admin Portal.
+ * Tracks listing authors (người đăng tin) by their reports and blocks/unblocks
+ * them from posting new listings.
+ */
+export class ReportedAuthorService {
+  /**
+   * Paginated list of authors with reports on their listings.
+   * GET /v1/admin/reported-authors
+   */
+  static async getReportedAuthors(params: {
+    page?: number
+    size?: number
+  }): Promise<ApiResponse<ReportedAuthorListResponse>> {
+    return apiRequest<ReportedAuthorListResponse>({
+      method: 'GET',
+      url: PATHS.REPORTED_AUTHORS.LIST,
+      params,
+    })
+  }
+
+  /**
+   * All admin-approved (RESOLVED) reports across an author's listings.
+   * GET /v1/admin/reported-authors/{userId}/reports
+   */
+  static async getApprovedReports(
+    userId: string,
+  ): Promise<ApiResponse<ListingReport[]>> {
+    return apiRequest<ListingReport[]>({
+      method: 'GET',
+      url: PATHS.REPORTED_AUTHORS.REPORTS.replace(':userId', userId),
+    })
+  }
+
+  /**
+   * Block or unblock an author from posting new listings.
+   * PATCH /v1/admin/reported-authors/{userId}/posting-block
+   */
+  static async setPostingBlock(
+    userId: string,
+    data: PostingBlockRequest,
+  ): Promise<ApiResponse<ReportedAuthor>> {
+    return apiRequest<ReportedAuthor>({
+      method: 'PATCH',
+      url: PATHS.REPORTED_AUTHORS.POSTING_BLOCK.replace(':userId', userId),
+      data,
+    })
+  }
+}

--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -28,7 +28,11 @@ export type ModerationStatus =
   | 'RESUBMITTED'
 
 // Decision for moderation action
-export type ModerationDecision = 'APPROVE' | 'REJECT' | 'REQUEST_REVISION'
+export type ModerationDecision =
+  | 'APPROVE'
+  | 'REJECT'
+  | 'REQUEST_REVISION'
+  | 'SUSPEND'
 
 // Admin Verification Info
 export interface AdminVerification {

--- a/src/api/types/reported-author.type.ts
+++ b/src/api/types/reported-author.type.ts
@@ -1,0 +1,30 @@
+// Types for the reported-authors (người đăng tin) admin feature
+
+export interface ReportedAuthor {
+  userId: string
+  firstName: string | null
+  lastName: string | null
+  email: string | null
+  phoneNumber: string | null
+  avatarUrl: string | null
+  totalReports: number
+  resolvedReports: number
+  /** true when resolvedReports > 3 → eligible to be blocked from posting */
+  blockEligible: boolean
+  postingBlocked: boolean
+  postingBlockedReason: string | null
+  postingBlockedAt: string | null
+}
+
+export interface ReportedAuthorListResponse {
+  page: number
+  size: number
+  totalElements: number
+  totalPages: number
+  data: ReportedAuthor[]
+}
+
+export interface PostingBlockRequest {
+  blocked: boolean
+  reason?: string
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -19,6 +19,7 @@ const ACTIVE_MAP: Record<string, string> = {
   '/monetization/listing-types': 'premiumListingTypes',
   '/moderation/broker-pending': 'brokerPending',
   '/moderation/reports': 'reports',
+  '/moderation/authors': 'authors',
 }
 
 export default function DashboardLayout({

--- a/src/app/(dashboard)/moderation/authors/page.tsx
+++ b/src/app/(dashboard)/moderation/authors/page.tsx
@@ -1,0 +1,5 @@
+import ReportedAuthors from '@/components/features/authors/authors-page'
+
+export default function ModerationAuthorsRoute() {
+  return <ReportedAuthors />
+}

--- a/src/components/features/authors/authors-page.tsx
+++ b/src/components/features/authors/authors-page.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import React, { useCallback, useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import { toast } from 'sonner'
+import { Button } from '@/components/atoms/button'
+import { ReportedAuthorService } from '@/api/services/reported-author.service'
+import { ReportedAuthor } from '@/api/types/reported-author.type'
+import { AuthorTable } from '@/components/organisms/authors/AuthorTable'
+import { AuthorReportsDialog } from '@/components/organisms/authors/AuthorReportsDialog'
+import { AuthorBlockDialog } from '@/components/organisms/authors/AuthorBlockDialog'
+
+const ReportedAuthors = () => {
+  const t = useTranslations('authors')
+  const tCommon = useTranslations('common')
+
+  const [authors, setAuthors] = useState<ReportedAuthor[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [totalItems, setTotalItems] = useState(0)
+  const [filterValues, setFilterValues] = useState<Record<string, unknown>>({
+    page: 1,
+    pageSize: 20,
+  })
+
+  // Dialog state
+  const [reportsAuthor, setReportsAuthor] = useState<ReportedAuthor | null>(
+    null,
+  )
+  const [blockAuthor, setBlockAuthor] = useState<ReportedAuthor | null>(null)
+  const [blocking, setBlocking] = useState(false)
+
+  const fetchAuthors = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await ReportedAuthorService.getReportedAuthors({
+        page: filterValues.page ? Number(filterValues.page) : 1,
+        size: filterValues.pageSize ? Number(filterValues.pageSize) : 20,
+      })
+      if (res.success && res.data) {
+        setAuthors(res.data.data)
+        setTotalItems(res.data.totalElements)
+      } else {
+        setError(res.message || t('table.loadError'))
+      }
+    } catch (err) {
+      console.error('Error fetching reported authors:', err)
+      setError(t('table.loadError'))
+    } finally {
+      setLoading(false)
+    }
+  }, [filterValues, t])
+
+  useEffect(() => {
+    fetchAuthors()
+  }, [fetchAuthors])
+
+  const handleFilterChange = (newFilters: Record<string, unknown>) => {
+    setFilterValues((prev) => ({
+      ...newFilters,
+      page: (newFilters.page as number | undefined) ?? 1,
+      pageSize:
+        (newFilters.pageSize as number | undefined) ?? prev.pageSize ?? 20,
+    }))
+  }
+
+  // The reports dialog and the table both request a block/unblock; funnel both
+  // into the confirmation dialog.
+  const openBlockFlow = (author: ReportedAuthor) => {
+    setReportsAuthor(null)
+    setBlockAuthor(author)
+  }
+
+  const handleConfirmBlock = async (blocked: boolean, reason: string) => {
+    if (!blockAuthor) return
+    setBlocking(true)
+    try {
+      const res = await ReportedAuthorService.setPostingBlock(
+        blockAuthor.userId,
+        { blocked, reason: reason || undefined },
+      )
+      if (res.success) {
+        toast.success(
+          blocked ? t('toasts.blockSuccess') : t('toasts.unblockSuccess'),
+        )
+        setBlockAuthor(null)
+        await fetchAuthors()
+      } else {
+        toast.error(res.message || t('toasts.blockError'))
+      }
+    } catch (err) {
+      console.error('Error toggling posting block:', err)
+      toast.error(t('toasts.blockError'))
+    } finally {
+      setBlocking(false)
+    }
+  }
+
+  if (error) {
+    return (
+      <div className='flex items-center justify-center py-12'>
+        <div className='max-w-sm space-y-3 rounded-xl border border-destructive/25 bg-destructive/6 p-6 text-center'>
+          <p className='text-sm text-destructive'>{error}</p>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => window.location.reload()}
+          >
+            {tCommon('retry')}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className='space-y-6'>
+      <div>
+        <h1 className='text-xl font-semibold text-foreground'>{t('title')}</h1>
+        <p className='mt-1 text-sm text-muted-foreground'>{t('subtitle')}</p>
+      </div>
+
+      <AuthorTable
+        authors={authors}
+        totalItems={totalItems}
+        loading={loading}
+        filterValues={filterValues}
+        onFilterChange={handleFilterChange}
+        onViewReports={setReportsAuthor}
+        onToggleBlock={openBlockFlow}
+      />
+
+      <AuthorReportsDialog
+        open={!!reportsAuthor}
+        onOpenChange={(open) => !open && setReportsAuthor(null)}
+        author={reportsAuthor}
+        onToggleBlock={openBlockFlow}
+      />
+
+      <AuthorBlockDialog
+        open={!!blockAuthor}
+        onOpenChange={(open) => !open && setBlockAuthor(null)}
+        author={blockAuthor}
+        loading={blocking}
+        onConfirm={handleConfirmBlock}
+      />
+    </div>
+  )
+}
+
+export default ReportedAuthors

--- a/src/components/organisms/adminSidebar.tsx
+++ b/src/components/organisms/adminSidebar.tsx
@@ -17,6 +17,7 @@ import {
   Shield,
   UserCheck,
   UserCogIcon,
+  UserSearch,
   Users,
   Newspaper,
   Crown,
@@ -250,6 +251,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
     news: <Newspaper width={20} />,
     brokerPending: <UserCheck width={20} />,
     reports: <Shield width={20} />,
+    authors: <UserSearch width={20} />,
   }
 
   const groupIconMap: Record<string, React.ReactNode> = {

--- a/src/components/organisms/authors/AuthorBlockDialog.tsx
+++ b/src/components/organisms/authors/AuthorBlockDialog.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/atoms/dialog'
+import { Button } from '@/components/atoms/button'
+import { Loader2 } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { ReportedAuthor } from '@/api/types/reported-author.type'
+
+interface AuthorBlockDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  author: ReportedAuthor | null
+  loading: boolean
+  /** Submit: blocked=true blocks with reason, blocked=false unblocks. */
+  onConfirm: (blocked: boolean, reason: string) => void | Promise<void>
+}
+
+const fullName = (a: ReportedAuthor) =>
+  `${a.firstName ?? ''} ${a.lastName ?? ''}`.trim() || a.userId
+
+/**
+ * Confirmation dialog for blocking (with reason) or unblocking an author from
+ * posting listings. Block mode shows a required-ish reason textarea.
+ */
+export const AuthorBlockDialog: React.FC<AuthorBlockDialogProps> = ({
+  open,
+  onOpenChange,
+  author,
+  loading,
+  onConfirm,
+}) => {
+  const t = useTranslations('authors')
+  const tCommon = useTranslations('common')
+  const [reason, setReason] = useState('')
+
+  // Blocking when the author is not currently blocked.
+  const isBlocking = !author?.postingBlocked
+
+  useEffect(() => {
+    if (open) setReason('')
+  }, [open, author])
+
+  if (!author) return null
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!loading) onOpenChange(next)
+      }}
+    >
+      <DialogContent className='max-w-md'>
+        <DialogHeader>
+          <DialogTitle>
+            {isBlocking
+              ? t('blockDialog.blockTitle')
+              : t('blockDialog.unblockTitle')}
+          </DialogTitle>
+          <DialogDescription>
+            {isBlocking
+              ? t('blockDialog.blockDescription', { name: fullName(author) })
+              : t('blockDialog.unblockDescription', { name: fullName(author) })}
+          </DialogDescription>
+        </DialogHeader>
+
+        {isBlocking && (
+          <div className='space-y-2'>
+            <label
+              htmlFor='block-reason'
+              className='block text-sm font-medium text-foreground/80'
+            >
+              {t('blockDialog.reasonLabel')}
+            </label>
+            <textarea
+              id='block-reason'
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              placeholder={t('blockDialog.reasonPlaceholder')}
+              rows={3}
+              className='w-full rounded-xl border border-border bg-background px-3 py-2 text-sm focus:border-primary/60 focus:outline-none focus:ring-2 focus:ring-ring'
+            />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button
+            type='button'
+            variant='outline'
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+            className='flex-1 sm:flex-none'
+          >
+            {tCommon('cancel')}
+          </Button>
+          <Button
+            type='button'
+            onClick={() => onConfirm(isBlocking, reason)}
+            disabled={loading}
+            className={cn(
+              'flex-1 sm:flex-none',
+              isBlocking &&
+                'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+            )}
+          >
+            {loading && <Loader2 className='h-4 w-4 animate-spin' />}
+            {isBlocking ? t('table.actions.block') : t('table.actions.unblock')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/organisms/authors/AuthorReportsDialog.tsx
+++ b/src/components/organisms/authors/AuthorReportsDialog.tsx
@@ -1,0 +1,221 @@
+'use client'
+
+import React, { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/atoms/dialog'
+import { Button } from '@/components/atoms/button'
+import { Badge } from '@/components/atoms/badge'
+import {
+  Loader2,
+  AlertTriangle,
+  Ban,
+  ShieldCheck,
+  CheckCircle,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import { ReportedAuthorService } from '@/api/services/reported-author.service'
+import { ReportedAuthor } from '@/api/types/reported-author.type'
+import { ListingReport } from '@/api/types/listing-report.type'
+import { formatDateTimeParts } from '@/utils/format'
+
+interface AuthorReportsDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  author: ReportedAuthor | null
+  /** Fires when the admin clicks block / unblock; parent opens the confirm flow. */
+  onToggleBlock: (author: ReportedAuthor) => void
+}
+
+/** Threshold above which an author is eligible to be blocked (mirrors backend). */
+const BLOCK_ELIGIBLE_THRESHOLD = 3
+
+const fullName = (a: ReportedAuthor) =>
+  `${a.firstName ?? ''} ${a.lastName ?? ''}`.trim() || a.userId
+
+export const AuthorReportsDialog: React.FC<AuthorReportsDialogProps> = ({
+  open,
+  onOpenChange,
+  author,
+  onToggleBlock,
+}) => {
+  const t = useTranslations('authors')
+  const [reports, setReports] = useState<ListingReport[]>([])
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (open && author) {
+      setReports([])
+      fetchReports(author.userId)
+    }
+  }, [open, author])
+
+  const fetchReports = async (userId: string) => {
+    try {
+      setLoading(true)
+      const res = await ReportedAuthorService.getApprovedReports(userId)
+      if (res.success && res.data) {
+        setReports(res.data)
+      } else {
+        toast.error(res.message || t('reportsDialog.loadError'))
+      }
+    } catch (e) {
+      console.error('Error loading author reports:', e)
+      toast.error(t('reportsDialog.loadError'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!author) return null
+
+  const eligible = author.resolvedReports > BLOCK_ELIGIBLE_THRESHOLD
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className='flex max-h-[90vh] w-[calc(100%-2rem)] max-w-2xl flex-col overflow-hidden p-0 gap-0'>
+        <DialogHeader className='shrink-0 border-b border-border/60 px-6 py-4'>
+          <DialogTitle className='text-lg font-semibold'>
+            {t('reportsDialog.title', { name: fullName(author) })}
+          </DialogTitle>
+          <DialogDescription>
+            {t('reportsDialog.subtitle', { count: author.resolvedReports })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className='min-h-0 flex-1 overflow-y-auto px-6 py-5'>
+          {/* Block-eligibility notice */}
+          {eligible && !author.postingBlocked && (
+            <div className='mb-4 flex items-start gap-2 rounded-xl border border-warning/40 bg-warning/10 p-3 text-sm text-warning-foreground'>
+              <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' />
+              <span>
+                {t('reportsDialog.eligibleNotice', {
+                  count: author.resolvedReports,
+                  threshold: BLOCK_ELIGIBLE_THRESHOLD,
+                })}
+              </span>
+            </div>
+          )}
+          {author.postingBlocked && (
+            <div className='mb-4 flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive'>
+              <Ban className='mt-0.5 h-4 w-4 shrink-0' />
+              <span>
+                {t('reportsDialog.blockedNotice')}
+                {author.postingBlockedReason
+                  ? ` — ${author.postingBlockedReason}`
+                  : ''}
+              </span>
+            </div>
+          )}
+
+          {loading ? (
+            <div className='flex items-center justify-center py-10'>
+              <Loader2 className='h-6 w-6 animate-spin text-primary' />
+            </div>
+          ) : reports.length === 0 ? (
+            <div className='rounded-xl border border-border/70 p-6 text-center text-sm text-muted-foreground'>
+              {t('reportsDialog.empty')}
+            </div>
+          ) : (
+            <ul className='space-y-3'>
+              {reports.map((report) => (
+                <li
+                  key={report.reportId}
+                  className='rounded-xl border border-border/70 bg-muted/40 p-4'
+                >
+                  <div className='flex items-start justify-between gap-3'>
+                    <div className='min-w-0'>
+                      <div className='flex items-center gap-2'>
+                        <span className='text-sm font-medium text-foreground'>
+                          #{report.reportId}
+                        </span>
+                        <Badge variant='success' className='gap-1 text-xs'>
+                          <CheckCircle className='h-3 w-3' />
+                          {t('reportsDialog.approved')}
+                        </Badge>
+                      </div>
+                      <p className='mt-1 text-xs text-muted-foreground'>
+                        {t('reportsDialog.listingPrefix')}
+                        {report.listingId}
+                      </p>
+                    </div>
+                    {report.resolvedAt && (
+                      <span className='shrink-0 text-xs text-muted-foreground'>
+                        {formatDateTimeParts(report.resolvedAt).date}
+                      </span>
+                    )}
+                  </div>
+
+                  {report.reportReasons && report.reportReasons.length > 0 && (
+                    <div className='mt-2 flex flex-wrap gap-1.5'>
+                      {report.reportReasons.map((reason) => (
+                        <Badge
+                          key={reason.reasonId}
+                          variant='outline'
+                          className='text-xs'
+                        >
+                          {reason.reasonText}
+                        </Badge>
+                      ))}
+                    </div>
+                  )}
+
+                  {report.otherFeedback && (
+                    <p className='mt-2 whitespace-pre-wrap text-sm text-foreground/80'>
+                      {report.otherFeedback}
+                    </p>
+                  )}
+
+                  {report.adminNotes && (
+                    <div className='mt-2 rounded-lg border border-border/60 bg-background p-2'>
+                      <span className='text-xs font-medium text-muted-foreground'>
+                        {t('reportsDialog.adminNotes')}:{' '}
+                      </span>
+                      <span className='text-sm text-foreground/80'>
+                        {report.adminNotes}
+                      </span>
+                      {report.resolvedByName && (
+                        <span className='ml-1 text-xs text-muted-foreground'>
+                          ({report.resolvedByName})
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer with block / unblock action */}
+        <div className='shrink-0 border-t border-border/60 px-6 py-4'>
+          <div className='flex justify-end'>
+            {author.postingBlocked ? (
+              <Button variant='outline' onClick={() => onToggleBlock(author)}>
+                <ShieldCheck className='h-4 w-4' />
+                {t('table.actions.unblock')}
+              </Button>
+            ) : (
+              <Button
+                variant='destructive'
+                disabled={!eligible}
+                title={
+                  !eligible ? t('table.actions.blockDisabledHint') : undefined
+                }
+                onClick={() => onToggleBlock(author)}
+              >
+                <Ban className='h-4 w-4' />
+                {t('table.actions.block')}
+              </Button>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/components/organisms/authors/AuthorTable.tsx
+++ b/src/components/organisms/authors/AuthorTable.tsx
@@ -1,0 +1,166 @@
+'use client'
+
+import React from 'react'
+import { useTranslations } from 'next-intl'
+import { Eye, Ban, ShieldCheck, AlertTriangle } from 'lucide-react'
+import { DataTable } from '@/components/organisms/DataTable'
+import type { Column } from '@/components/organisms/DataTable/types'
+import { Button } from '@/components/atoms/button'
+import { Badge } from '@/components/atoms/badge'
+import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
+import { ReportedAuthor } from '@/api/types/reported-author.type'
+
+interface AuthorTableProps {
+  authors: ReportedAuthor[]
+  totalItems: number
+  loading: boolean
+  filterValues: Record<string, unknown>
+  onFilterChange: (filters: Record<string, unknown>) => void
+  onViewReports: (author: ReportedAuthor) => void
+  onToggleBlock: (author: ReportedAuthor) => void
+}
+
+const fullName = (a: ReportedAuthor) =>
+  `${a.firstName ?? ''} ${a.lastName ?? ''}`.trim() || a.userId
+
+export const AuthorTable: React.FC<AuthorTableProps> = ({
+  authors,
+  totalItems,
+  loading,
+  filterValues,
+  onFilterChange,
+  onViewReports,
+  onToggleBlock,
+}) => {
+  const t = useTranslations('authors')
+
+  const columns: Column<ReportedAuthor>[] = [
+    {
+      id: 'author',
+      header: t('table.headers.author'),
+      accessor: (row) => fullName(row),
+      render: (_v, row) => (
+        <div className='flex items-center gap-3'>
+          <InitialsAvatar name={fullName(row)} src={row.avatarUrl} size='sm' />
+          <div className='min-w-0'>
+            <div className='truncate font-medium text-foreground'>
+              {fullName(row)}
+            </div>
+            <div className='truncate text-xs text-muted-foreground'>
+              {row.email || '—'}
+            </div>
+          </div>
+        </div>
+      ),
+    },
+    {
+      id: 'phone',
+      header: t('table.headers.phone'),
+      accessor: 'phoneNumber',
+      render: (v) => (
+        <span className='text-sm text-muted-foreground'>
+          {(v as string) || '—'}
+        </span>
+      ),
+    },
+    {
+      id: 'totalReports',
+      header: t('table.headers.totalReports'),
+      accessor: 'totalReports',
+      align: 'center',
+      render: (v) => <Badge variant='secondary'>{v as number}</Badge>,
+    },
+    {
+      id: 'resolvedReports',
+      header: t('table.headers.approvedReports'),
+      accessor: 'resolvedReports',
+      align: 'center',
+      render: (v, row) => (
+        <Badge variant={row.blockEligible ? 'warning' : 'secondary'}>
+          {v as number}
+        </Badge>
+      ),
+    },
+    {
+      id: 'status',
+      header: t('table.headers.status'),
+      accessor: 'postingBlocked',
+      render: (_v, row) => {
+        if (row.postingBlocked) {
+          return (
+            <Badge variant='destructive' className='gap-1'>
+              <Ban className='h-3 w-3' />
+              {t('status.blocked')}
+            </Badge>
+          )
+        }
+        if (row.blockEligible) {
+          return (
+            <Badge variant='warning' className='gap-1'>
+              <AlertTriangle className='h-3 w-3' />
+              {t('status.eligible')}
+            </Badge>
+          )
+        }
+        return (
+          <Badge variant='success' className='gap-1'>
+            <ShieldCheck className='h-3 w-3' />
+            {t('status.active')}
+          </Badge>
+        )
+      },
+    },
+  ]
+
+  return (
+    <DataTable
+      data={authors}
+      columns={columns}
+      filterMode='api'
+      filterValues={filterValues}
+      onFilterChange={onFilterChange}
+      totalItems={totalItems}
+      itemsPerPageOptions={[10, 20, 50]}
+      loading={loading}
+      emptyMessage={t('table.empty')}
+      getRowKey={(row) => row.userId}
+      actions={(row) => (
+        <div className='flex items-center justify-end gap-2'>
+          <Button
+            variant='outline'
+            size='sm'
+            onClick={() => onViewReports(row)}
+          >
+            <Eye className='h-4 w-4' />
+            {t('table.actions.viewReports')}
+          </Button>
+          {row.postingBlocked ? (
+            <Button
+              variant='outline'
+              size='sm'
+              onClick={() => onToggleBlock(row)}
+            >
+              <ShieldCheck className='h-4 w-4' />
+              {t('table.actions.unblock')}
+            </Button>
+          ) : (
+            <Button
+              variant='destructive'
+              size='sm'
+              disabled={!row.blockEligible}
+              title={
+                !row.blockEligible
+                  ? t('table.actions.blockDisabledHint')
+                  : undefined
+              }
+              onClick={() => onToggleBlock(row)}
+            >
+              <Ban className='h-4 w-4' />
+              {t('table.actions.block')}
+            </Button>
+          )}
+        </div>
+      )}
+    />
+  )
+}

--- a/src/components/organisms/reports/ReportReviewModal.tsx
+++ b/src/components/organisms/reports/ReportReviewModal.tsx
@@ -13,6 +13,7 @@ import { Avatar } from '@/components/atoms/avatar'
 import {
   AlertTriangle,
   Eye,
+  EyeOff,
   CheckCircle,
   XCircle,
   Loader2,
@@ -104,6 +105,7 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
   const [loadingListing, setLoadingListing] = useState(false)
   const [actionReason, setActionReason] = useState('')
   const [actionLoading, setActionLoading] = useState(false)
+  const [visibilityLoading, setVisibilityLoading] = useState(false)
 
   // Lightbox state
   const [lightboxOpen, setLightboxOpen] = useState(false)
@@ -186,6 +188,38 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
       toast.error(t('toasts.dismissError'))
     } finally {
       setActionLoading(false)
+    }
+  }
+
+  const handleHideListing = async () => {
+    if (!report) return
+    try {
+      setVisibilityLoading(true)
+      await ListingService.hideListing(report.listingId, t('review.hideReason'))
+      toast.success(t('toasts.hideSuccess'))
+      await fetchListingDetails(report.listingId)
+      onActionComplete()
+    } catch (e) {
+      console.error('Error hiding listing:', e)
+      toast.error(t('toasts.hideError'))
+    } finally {
+      setVisibilityLoading(false)
+    }
+  }
+
+  const handleUnhideListing = async () => {
+    if (!report) return
+    try {
+      setVisibilityLoading(true)
+      await ListingService.unhideListing(report.listingId)
+      toast.success(t('toasts.unhideSuccess'))
+      await fetchListingDetails(report.listingId)
+      onActionComplete()
+    } catch (e) {
+      console.error('Error unhiding listing:', e)
+      toast.error(t('toasts.unhideError'))
+    } finally {
+      setVisibilityLoading(false)
     }
   }
 
@@ -536,6 +570,44 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                           <Badge className='text-xs bg-muted text-muted-foreground border-border/70'>
                             {t('review.expired')}
                           </Badge>
+                        )}
+                        {listingDetails.moderationStatus === 'SUSPENDED' && (
+                          <Badge className='text-xs bg-destructive/10 text-destructive border-destructive/30'>
+                            {t('review.hidden')}
+                          </Badge>
+                        )}
+
+                        {/* Temporary hide / unhide toggle */}
+                        {listingDetails.moderationStatus === 'SUSPENDED' ? (
+                          <Button
+                            size='sm'
+                            variant='outline'
+                            className='ml-auto text-sm'
+                            onClick={handleUnhideListing}
+                            disabled={visibilityLoading}
+                          >
+                            {visibilityLoading ? (
+                              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                            ) : (
+                              <Eye className='mr-2 h-4 w-4' />
+                            )}
+                            {t('review.unhide')}
+                          </Button>
+                        ) : (
+                          <Button
+                            size='sm'
+                            variant='outline'
+                            className='ml-auto border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground text-sm'
+                            onClick={handleHideListing}
+                            disabled={visibilityLoading}
+                          >
+                            {visibilityLoading ? (
+                              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                            ) : (
+                              <EyeOff className='mr-2 h-4 w-4' />
+                            )}
+                            {t('review.hide')}
+                          </Button>
                         )}
                       </div>
                     </div>

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -30,6 +30,7 @@ type PageKey =
   | 'news'
   | 'newsEditor'
   | 'reports'
+  | 'authors'
 
 const ROUTE_META: Record<string, { category: CategoryKey; page: PageKey }> = {
   '/management/users': { category: 'management', page: 'users' },
@@ -68,6 +69,7 @@ const ROUTE_META: Record<string, { category: CategoryKey; page: PageKey }> = {
   '/content/news': { category: 'content', page: 'news' },
   '/content/news-editor': { category: 'content', page: 'newsEditor' },
   '/moderation/reports': { category: 'moderation', page: 'reports' },
+  '/moderation/authors': { category: 'moderation', page: 'authors' },
 }
 
 const CATEGORY_ROUTES: Record<CategoryKey, string[]> = {
@@ -84,7 +86,11 @@ const CATEGORY_ROUTES: Record<CategoryKey, string[]> = {
     '/management/transactions',
   ],
   content: ['/content/posts', '/content/news'],
-  moderation: ['/moderation/reports', '/moderation/broker-pending'],
+  moderation: [
+    '/moderation/reports',
+    '/moderation/authors',
+    '/moderation/broker-pending',
+  ],
   monetization: ['/monetization/membership', '/monetization/listing-types'],
 }
 
@@ -122,6 +128,7 @@ const LABELS = {
       news: 'News',
       newsEditor: 'Editor',
       reports: 'Reports',
+      authors: 'Post Authors',
     } as Record<PageKey, string>,
   } satisfies NavigationLabels,
   vi: {
@@ -150,6 +157,7 @@ const LABELS = {
       news: 'Tin tức',
       newsEditor: 'Trình biên tập',
       reports: 'Báo cáo',
+      authors: 'Người đăng tin',
     } as Record<PageKey, string>,
   } satisfies NavigationLabels,
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1946,7 +1946,11 @@
       "removeListingNoteRequired": "Please provide a reason for suspending this listing",
       "removeListingConfirm": "Are you sure you want to permanently suspend this listing? The owner will not be able to resubmit it.",
       "removeListingSuccess": "Listing has been permanently suspended",
-      "removeListingError": "Failed to suspend the listing. Please try again."
+      "removeListingError": "Failed to suspend the listing. Please try again.",
+      "hideSuccess": "Listing has been temporarily hidden.",
+      "hideError": "Failed to hide the listing.",
+      "unhideSuccess": "Listing is visible again.",
+      "unhideError": "Failed to unhide the listing."
     },
     "table": {
       "viewDetails": "View Details",
@@ -1989,7 +1993,11 @@
       "couldNotLoad": "Could not load listing details",
       "reportPrefix": "Report #",
       "loadingDetails": "Loading listing details...",
-      "listingIdPrefix": "Listing ID: #"
+      "listingIdPrefix": "Listing ID: #",
+      "hide": "Hide temporarily",
+      "unhide": "Unhide",
+      "hidden": "Hidden",
+      "hideReason": "Temporarily hidden due to a report under review"
     },
     "categories": {
       "LISTING": "Listing",
@@ -2408,6 +2416,56 @@
       "newReport": "A new report has been submitted",
       "listingResubmitted": "A listing has been resubmitted for review",
       "brokerRegistrationReceived": "A broker registration request was received"
+    }
+  },
+  "authors": {
+    "title": "Post Authors",
+    "subtitle": "Track listing authors by their reports and block repeat offenders from posting.",
+    "table": {
+      "loadError": "Failed to load authors. Please try again.",
+      "empty": "No reported authors yet.",
+      "headers": {
+        "author": "Author",
+        "phone": "Phone",
+        "totalReports": "Total reports",
+        "approvedReports": "Approved reports",
+        "status": "Status"
+      },
+      "actions": {
+        "viewReports": "View reports",
+        "block": "Block posting",
+        "unblock": "Unblock",
+        "blockDisabledHint": "Needs more than 3 approved reports to be blocked"
+      }
+    },
+    "status": {
+      "active": "Active",
+      "eligible": "Eligible to block",
+      "blocked": "Blocked"
+    },
+    "reportsDialog": {
+      "title": "Approved reports — {name}",
+      "subtitle": "{count} report(s) approved by admins across this author's listings.",
+      "loadError": "Failed to load reports.",
+      "empty": "This author has no admin-approved reports.",
+      "approved": "Approved",
+      "listingPrefix": "Listing #",
+      "adminNotes": "Admin notes",
+      "eligibleNotice": "This author has {count} approved reports (more than {threshold}) and is eligible to be blocked from posting.",
+      "blockedNotice": "This author is currently blocked from posting."
+    },
+    "blockDialog": {
+      "blockTitle": "Block author from posting",
+      "unblockTitle": "Unblock author",
+      "blockDescription": "{name} will no longer be able to create new listings. They will see a notice and be blocked on the backend.",
+      "unblockDescription": "{name} will be able to post listings again.",
+      "reasonLabel": "Reason (optional)",
+      "reasonPlaceholder": "e.g. Multiple listings with approved violation reports"
+    },
+    "toasts": {
+      "blockSuccess": "Author has been blocked from posting.",
+      "unblockSuccess": "Author can post listings again.",
+      "blockError": "Failed to update posting block. Please try again."
     }
   }
 }

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1910,7 +1910,11 @@
       "removeListingNoteRequired": "Vui lòng nhập lý do đình chỉ tin đăng",
       "removeListingConfirm": "Bạn có chắc chắn muốn đình chỉ vĩnh viễn tin đăng này? Chủ tin đăng sẽ không thể đăng lại tin này.",
       "removeListingSuccess": "Đã đình chỉ tin đăng vĩnh viễn",
-      "removeListingError": "Không thể đình chỉ tin đăng. Vui lòng thử lại."
+      "removeListingError": "Không thể đình chỉ tin đăng. Vui lòng thử lại.",
+      "hideSuccess": "Đã ẩn tạm thời tin đăng.",
+      "hideError": "Ẩn tin đăng thất bại.",
+      "unhideSuccess": "Tin đăng đã hiển thị trở lại.",
+      "unhideError": "Hiện lại tin đăng thất bại."
     },
     "table": {
       "viewDetails": "Xem Chi Tiết",
@@ -1953,7 +1957,11 @@
       "couldNotLoad": "Không thể tải thông tin bài đăng",
       "reportPrefix": "Báo cáo #",
       "loadingDetails": "Đang tải thông tin tin đăng...",
-      "listingIdPrefix": "Tin đăng #"
+      "listingIdPrefix": "Tin đăng #",
+      "hide": "Ẩn tạm thời",
+      "unhide": "Hiện lại",
+      "hidden": "Đã ẩn",
+      "hideReason": "Tạm ẩn do có báo cáo đang được xem xét"
     },
     "categories": {
       "LISTING": "Tin Đăng",
@@ -2372,6 +2380,56 @@
       "newReport": "Có báo cáo mới được gửi",
       "listingResubmitted": "Tin đăng đã được gửi lại để duyệt",
       "brokerRegistrationReceived": "Có đơn đăng ký môi giới mới"
+    }
+  },
+  "authors": {
+    "title": "Người đăng tin",
+    "subtitle": "Theo dõi người đăng tin theo các report và chặn đăng tin với người vi phạm nhiều lần.",
+    "table": {
+      "loadError": "Không tải được danh sách. Vui lòng thử lại.",
+      "empty": "Chưa có người đăng tin nào bị báo cáo.",
+      "headers": {
+        "author": "Người đăng tin",
+        "phone": "Điện thoại",
+        "totalReports": "Tổng report",
+        "approvedReports": "Report đã duyệt",
+        "status": "Trạng thái"
+      },
+      "actions": {
+        "viewReports": "Xem report",
+        "block": "Chặn đăng tin",
+        "unblock": "Mở lại",
+        "blockDisabledHint": "Cần trên 3 report đã duyệt mới đủ điều kiện chặn"
+      }
+    },
+    "status": {
+      "active": "Bình thường",
+      "eligible": "Đủ điều kiện chặn",
+      "blocked": "Đã chặn"
+    },
+    "reportsDialog": {
+      "title": "Report đã duyệt — {name}",
+      "subtitle": "{count} report đã được admin duyệt trên các tin của người này.",
+      "loadError": "Không tải được danh sách report.",
+      "empty": "Người này chưa có report nào được admin duyệt.",
+      "approved": "Đã duyệt",
+      "listingPrefix": "Tin #",
+      "adminNotes": "Ghi chú admin",
+      "eligibleNotice": "Người này có {count} report đã duyệt (trên {threshold}), đủ điều kiện bị chặn đăng tin.",
+      "blockedNotice": "Người này hiện đang bị chặn đăng tin."
+    },
+    "blockDialog": {
+      "blockTitle": "Chặn đăng tin",
+      "unblockTitle": "Mở lại quyền đăng tin",
+      "blockDescription": "{name} sẽ không thể đăng tin mới. Người dùng sẽ thấy thông báo và bị chặn ở backend.",
+      "unblockDescription": "{name} sẽ có thể đăng tin trở lại.",
+      "reasonLabel": "Lý do (không bắt buộc)",
+      "reasonPlaceholder": "vd: Nhiều tin đăng có report vi phạm đã được duyệt"
+    },
+    "toasts": {
+      "blockSuccess": "Đã chặn đăng tin với người này.",
+      "unblockSuccess": "Đã mở lại quyền đăng tin.",
+      "blockError": "Cập nhật chặn đăng tin thất bại. Vui lòng thử lại."
     }
   }
 }


### PR DESCRIPTION
Add a "Post Authors" (Người đăng tin) moderation tab to track listing authors by their reports, view admin-approved (RESOLVED) reports, and block/unblock them from posting when they exceed 3 approved reports.

Also add temporary hide / unhide of a reported listing directly from the report review modal (moderation SUSPEND/APPROVE), with a "Hidden" badge.

Includes new authors service/types, nav registration, sidebar icon, and vi/en translations.