### PR TITLE
feat: reported-authors filters + faster block toggle

### DIFF
--- a/src/api/services/reported-author.service.ts
+++ b/src/api/services/reported-author.service.ts
@@ -21,6 +21,10 @@ export class ReportedAuthorService {
   static async getReportedAuthors(params: {
     page?: number
     size?: number
+    email?: string
+    name?: string
+    phone?: string
+    blockEligible?: boolean
   }): Promise<ApiResponse<ReportedAuthorListResponse>> {
     return apiRequest<ReportedAuthorListResponse>({
       method: 'GET',

--- a/src/components/features/authors/authors-page.tsx
+++ b/src/components/features/authors/authors-page.tsx
@@ -34,9 +34,19 @@ const ReportedAuthors = () => {
     setLoading(true)
     setError(null)
     try {
+      const blockEligibleRaw = filterValues.blockEligible as string | undefined
       const res = await ReportedAuthorService.getReportedAuthors({
         page: filterValues.page ? Number(filterValues.page) : 1,
         size: filterValues.pageSize ? Number(filterValues.pageSize) : 10,
+        email: (filterValues.email as string) || undefined,
+        name: (filterValues.name as string) || undefined,
+        phone: (filterValues.phone as string) || undefined,
+        blockEligible:
+          blockEligibleRaw === 'true'
+            ? true
+            : blockEligibleRaw === 'false'
+              ? false
+              : undefined,
       })
       if (res.success && res.data) {
         setAuthors(res.data.data)
@@ -84,8 +94,22 @@ const ReportedAuthors = () => {
         toast.success(
           blocked ? t('toasts.blockSuccess') : t('toasts.unblockSuccess'),
         )
+        // Update just the toggled row in place — a block/unblock never changes
+        // the report counts, so avoid re-running the whole reported-authors
+        // aggregate query (which made the toggle feel slow).
+        setAuthors((prev) =>
+          prev.map((a) =>
+            a.userId === blockAuthor.userId
+              ? {
+                  ...a,
+                  postingBlocked: res.data?.postingBlocked ?? blocked,
+                  postingBlockedReason: res.data?.postingBlockedReason ?? null,
+                  postingBlockedAt: res.data?.postingBlockedAt ?? null,
+                }
+              : a,
+          ),
+        )
         setBlockAuthor(null)
-        await fetchAuthors()
       } else {
         toast.error(res.message || t('toasts.blockError'))
       }

--- a/src/components/organisms/authors/AuthorTable.tsx
+++ b/src/components/organisms/authors/AuthorTable.tsx
@@ -4,7 +4,10 @@ import React from 'react'
 import { useTranslations } from 'next-intl'
 import { Eye, Ban, ShieldCheck, AlertTriangle } from 'lucide-react'
 import { DataTable } from '@/components/organisms/DataTable'
-import type { Column } from '@/components/organisms/DataTable/types'
+import type {
+  Column,
+  FilterConfig,
+} from '@/components/organisms/DataTable/types'
 import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
 import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
@@ -112,10 +115,45 @@ export const AuthorTable: React.FC<AuthorTableProps> = ({
     },
   ]
 
+  const filterConfig: FilterConfig[] = [
+    {
+      id: 'email',
+      type: 'search',
+      label: t('table.headers.email'),
+      placeholder: t('filters.emailPlaceholder'),
+      isFilterField: true,
+    },
+    {
+      id: 'name',
+      type: 'search',
+      label: t('table.headers.author'),
+      placeholder: t('filters.namePlaceholder'),
+      isFilterField: true,
+    },
+    {
+      id: 'phone',
+      type: 'search',
+      label: t('table.headers.phone'),
+      placeholder: t('filters.phonePlaceholder'),
+      isFilterField: true,
+    },
+    {
+      id: 'blockEligible',
+      type: 'select',
+      label: t('filters.blockEligible'),
+      isFilterField: true,
+      options: [
+        { value: 'true', label: t('filters.eligibleOnly') },
+        { value: 'false', label: t('filters.notEligibleOnly') },
+      ],
+    },
+  ]
+
   return (
     <DataTable
       data={authors}
       columns={columns}
+      filters={filterConfig}
       filterMode='api'
       filterValues={filterValues}
       onFilterChange={onFilterChange}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2429,7 +2429,8 @@
         "phone": "Phone",
         "totalReports": "Total reports",
         "approvedReports": "Approved reports",
-        "status": "Status"
+        "status": "Status",
+        "email": "Email"
       },
       "actions": {
         "viewReports": "View reports",
@@ -2466,6 +2467,14 @@
       "blockSuccess": "Author has been blocked from posting.",
       "unblockSuccess": "Author can post listings again.",
       "blockError": "Failed to update posting block. Please try again."
+    },
+    "filters": {
+      "emailPlaceholder": "Search by email",
+      "namePlaceholder": "Search by name",
+      "phonePlaceholder": "Search by phone",
+      "blockEligible": "Block eligibility",
+      "eligibleOnly": "Eligible to block",
+      "notEligibleOnly": "Not yet eligible"
     }
   }
 }

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2393,7 +2393,8 @@
         "phone": "Điện thoại",
         "totalReports": "Tổng report",
         "approvedReports": "Report đã duyệt",
-        "status": "Trạng thái"
+        "status": "Trạng thái",
+        "email": "Email"
       },
       "actions": {
         "viewReports": "Xem report",
@@ -2430,6 +2431,14 @@
       "blockSuccess": "Đã chặn đăng tin với người này.",
       "unblockSuccess": "Đã mở lại quyền đăng tin.",
       "blockError": "Cập nhật chặn đăng tin thất bại. Vui lòng thử lại."
+    },
+    "filters": {
+      "emailPlaceholder": "Tìm theo email",
+      "namePlaceholder": "Tìm theo tên",
+      "phonePlaceholder": "Tìm theo SĐT",
+      "blockEligible": "Đủ điều kiện chặn",
+      "eligibleOnly": "Đủ điều kiện chặn",
+      "notEligibleOnly": "Chưa đủ điều kiện"
     }
   }
 }


### PR DESCRIPTION
- Add email / name / phone / block-eligibility filters to the Post Authors table
- Optimistically update the toggled row on block/unblock instead of refetching the whole aggregate (fixes slow toggle)
- Wire filter params through the reported-authors service; vi/en translations