### PR TITLE
feat(admin): role-based sidebar and page-action gating

### DIFF
--- a/src/components/features/auth/login-page.tsx
+++ b/src/components/features/auth/login-page.tsx
@@ -10,20 +10,22 @@ import { Skeleton } from '@/components/atoms/skeleton'
 import ThemeSwitch from '@/components/molecules/themeSwitch'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
 import { cn } from '@/lib/utils'
-import { DEFAULT_HOME_ROUTE } from '@/constants/navigation'
+import { resolveHomeRoute, toRoleIds } from '@/constants/navigation'
+import { useAuthStore } from '@/store/auth/index.store'
 
 const LoginPage = () => {
   const router = useRouter()
   const t = useTranslations('homePage.auth.login')
   const tBrand = useTranslations('homePage.auth.brand')
   const { isAuthenticated, isLoading } = useAuth()
+  const userRoles = useAuthStore((state) => state.user?.roles)
   const { language, updateLanguage } = useSwitchLanguage()
 
   useEffect(() => {
     if (!isLoading && isAuthenticated) {
-      router.push(DEFAULT_HOME_ROUTE)
+      router.push(resolveHomeRoute(toRoleIds(userRoles)))
     }
-  }, [isAuthenticated, isLoading, router])
+  }, [isAuthenticated, isLoading, userRoles, router])
 
   if (isLoading) {
     return (

--- a/src/components/features/premium/premium-section-page.tsx
+++ b/src/components/features/premium/premium-section-page.tsx
@@ -18,6 +18,7 @@ import { ListingTypeTable } from '@/components/organisms/premium/ListingTypeTabl
 import { EditMembershipDialog } from '@/components/organisms/premium/EditMembershipDialog'
 import { DeleteMembershipDialog } from '@/components/organisms/premium/DeleteMembershipDialog'
 import { ViewMembershipDialog } from '@/components/organisms/premium/ViewMembershipDialog'
+import { useCanWrite } from '@/hooks/usePermissions'
 
 export type PremiumSection = 'overview' | 'membership' | 'listing-types'
 
@@ -27,6 +28,7 @@ type PremiumSectionPageProps = {
 
 const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
   const t = useTranslations('premium')
+  const canWrite = useCanWrite('premiumMembership')
 
   const [apiMemberships, setApiMemberships] = useState<APIMembershipPackage[]>(
     [],
@@ -237,6 +239,7 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
             onEdit={handleEdit}
             onDelete={handleDelete}
             onToggleStatus={handleToggleStatus}
+            canWrite={canWrite}
           />
         </>
       )}

--- a/src/components/features/roles/roles-page.tsx
+++ b/src/components/features/roles/roles-page.tsx
@@ -14,6 +14,7 @@ import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { RoleCreateDialog } from '@/components/organisms/roles/RoleCreateDialog'
 import { RoleEditDialog } from '@/components/organisms/roles/RoleEditDialog'
 import { RoleDeleteDialog } from '@/components/organisms/roles/RoleDeleteDialog'
+import { useCanWrite } from '@/hooks/usePermissions'
 
 type RoleRow = {
   id: string
@@ -22,6 +23,7 @@ type RoleRow = {
 
 const RoleManagement = () => {
   const t = useTranslations('admin.roles')
+  const canWrite = useCanWrite('roles')
   const [roles, setRoles] = useState<Role[]>([])
   const [loading, setLoading] = useState(true)
   const [filterValues, setFilterValues] = useState<Record<string, unknown>>({
@@ -115,10 +117,12 @@ const RoleManagement = () => {
           columns={columns}
           filters={filterConfig}
           toolbarActions={
-            <Button size='sm' onClick={() => setShowCreate(true)}>
-              <Plus className='h-4 w-4' />
-              {t('createNewRole')}
-            </Button>
+            canWrite ? (
+              <Button size='sm' onClick={() => setShowCreate(true)}>
+                <Plus className='h-4 w-4' />
+                {t('createNewRole')}
+              </Button>
+            ) : undefined
           }
           filterMode='api'
           filterValues={filterValues}
@@ -130,34 +134,38 @@ const RoleManagement = () => {
           loading={loading}
           emptyMessage={loading ? t('table.loading') : t('table.empty')}
           getRowKey={(row) => row.id}
-          actions={(row) => (
-            <div className='flex items-center justify-center gap-0.5'>
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
-                title={t('table.actions.edit')}
-                onClick={() => {
-                  const role = roles.find((r) => r.roleId === row.id)
-                  if (role) setShowEdit(role)
-                }}
-              >
-                <Pencil className='h-4 w-4' />
-              </Button>
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
-                title={t('table.actions.delete')}
-                onClick={() => {
-                  const role = roles.find((r) => r.roleId === row.id)
-                  if (role) setShowDelete(role)
-                }}
-              >
-                <Trash2 className='h-4 w-4' />
-              </Button>
-            </div>
-          )}
+          actions={
+            canWrite
+              ? (row) => (
+                  <div className='flex items-center justify-center gap-0.5'>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
+                      title={t('table.actions.edit')}
+                      onClick={() => {
+                        const role = roles.find((r) => r.roleId === row.id)
+                        if (role) setShowEdit(role)
+                      }}
+                    >
+                      <Pencil className='h-4 w-4' />
+                    </Button>
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+                      title={t('table.actions.delete')}
+                      onClick={() => {
+                        const role = roles.find((r) => r.roleId === row.id)
+                        if (role) setShowDelete(role)
+                      }}
+                    >
+                      <Trash2 className='h-4 w-4' />
+                    </Button>
+                  </div>
+                )
+              : undefined
+          }
         />
 
         <RoleCreateDialog

--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -14,6 +14,7 @@ import { UserEditDialog } from '@/components/organisms/users/UserEditDialog'
 import { UserDeleteDialog } from '@/components/organisms/users/UserDeleteDialog'
 import { UserClearMembershipDialog } from '@/components/organisms/users/UserClearMembershipDialog'
 import { ConfirmDialog } from '@/components/molecules/confirmDialog'
+import { useCanWrite } from '@/hooks/usePermissions'
 
 const UserManagement = () => {
   // Modal states
@@ -28,6 +29,7 @@ const UserManagement = () => {
   const [removingBroker, setRemovingBroker] = useState(false)
   const t = useTranslations('admin.users')
   const tCommon = useTranslations('common')
+  const canWrite = useCanWrite('users')
 
   // State for API data
   const [users, setUsers] = useState<UserProfile[]>([])
@@ -158,11 +160,14 @@ const UserManagement = () => {
           onDelete={setShowDelete}
           onRemoveBroker={(user) => setRemoveBrokerUser(user)}
           onClearMembership={setShowClearMembership}
+          canWrite={canWrite}
           toolbarActions={
-            <Button size='sm' onClick={() => setShowCreate(true)}>
-              <Plus className='h-4 w-4' />
-              {t('create.button')}
-            </Button>
+            canWrite ? (
+              <Button size='sm' onClick={() => setShowCreate(true)}>
+                <Plus className='h-4 w-4' />
+                {t('create.button')}
+              </Button>
+            ) : undefined
           }
         />
       </div>

--- a/src/components/layouts/AppAdminLayout.tsx
+++ b/src/components/layouts/AppAdminLayout.tsx
@@ -8,7 +8,13 @@ import { useAuth, useAuthGuard } from '@/hooks/useAuth'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
 import { Skeleton } from '@/components/atoms/skeleton'
 import Breadcrumb from '@/components/molecules/breadcrumb'
-import { getBreadcrumbItems } from '@/constants/navigation'
+import {
+  canAccessPath,
+  getBreadcrumbItems,
+  resolveHomeRoute,
+  toRoleIds,
+} from '@/constants/navigation'
+import { useAuthStore } from '@/store/auth/index.store'
 
 type AppAdminLayoutProps = {
   children: React.ReactNode
@@ -23,9 +29,16 @@ const AppAdminLayout: React.FC<AppAdminLayoutProps> = ({
   const pathname = usePathname() ?? ''
   const { language } = useSwitchLanguage()
   const { isAuthenticated, isLoading } = useAuth()
+  const userRoles = useAuthStore((state) => state.user?.roles)
+  const roleIds = React.useMemo(() => toRoleIds(userRoles), [userRoles])
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
   const breadcrumbItems = getBreadcrumbItems(pathname, language)
+
+  // Skip the RBAC check until roles hydrate (empty) so we don't bounce a valid
+  // admin mid-load; the auth guard above still handles the unauthenticated case.
+  const isForbidden =
+    isAuthenticated && roleIds.length > 0 && !canAccessPath(pathname, roleIds)
 
   useAuthGuard()
 
@@ -34,6 +47,13 @@ const AppAdminLayout: React.FC<AppAdminLayoutProps> = ({
       router.push('/login')
     }
   }, [isAuthenticated, isLoading, router])
+
+  // Block direct-URL access to pages this admin's roles can't open.
+  useEffect(() => {
+    if (!isLoading && isForbidden) {
+      router.replace(resolveHomeRoute(roleIds))
+    }
+  }, [isLoading, isForbidden, roleIds, router])
 
   useEffect(() => {
     setMobileSidebarOpen(false)
@@ -58,7 +78,7 @@ const AppAdminLayout: React.FC<AppAdminLayoutProps> = ({
     )
   }
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated || isForbidden) {
     return null
   }
 

--- a/src/components/molecules/adminLoginForm/index.tsx
+++ b/src/components/molecules/adminLoginForm/index.tsx
@@ -11,7 +11,8 @@ import { useAdminLogin } from '@/hooks/useAuth'
 import { toast } from 'sonner'
 import { VALIDATION_PATTERNS } from '@/api/types/auth.type'
 import { useRouter } from 'next/navigation'
-import { DEFAULT_HOME_ROUTE } from '@/constants/navigation'
+import { resolveHomeRoute, toRoleIds } from '@/constants/navigation'
+import { useAuthStore } from '@/store/auth/index.store'
 
 type AdminLoginFormProps = {
   onSuccess?: () => void
@@ -65,7 +66,10 @@ const AdminLoginForm: NextPage<AdminLoginFormProps> = (props) => {
       if (result.success) {
         toast.success(t('homePage.auth.login.successMessage'))
         onSuccess?.()
-        router.push(DEFAULT_HOME_ROUTE)
+        // Land on the first page this admin's roles can actually open — the
+        // static default (/insights/users) is off-limits to some roles.
+        const roleIds = toRoleIds(useAuthStore.getState().user?.roles)
+        router.push(resolveHomeRoute(roleIds))
       } else {
         toast.error(result.message || t('homePage.auth.login.errorMessage'))
       }

--- a/src/components/organisms/adminSidebar.tsx
+++ b/src/components/organisms/adminSidebar.tsx
@@ -3,9 +3,11 @@ import { usePathname, useRouter } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { useSwitchLanguage } from '@/contexts/switchLanguage/index.context'
 import {
-  DEFAULT_HOME_ROUTE,
   getSidebarNavigationGroups,
+  resolveHomeRoute,
+  toRoleIds,
 } from '@/constants/navigation'
+import { useAuthStore } from '@/store/auth/index.store'
 import {
   ChevronRight,
   PanelLeftClose,
@@ -173,9 +175,11 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
   const router = useRouter()
   const pathname = usePathname() ?? ''
   const { language, updateLanguage } = useSwitchLanguage()
+  const userRoles = useAuthStore((state) => state.user?.roles)
+  const roleIds = React.useMemo(() => toRoleIds(userRoles), [userRoles])
   const navigationGroups = React.useMemo(
-    () => getSidebarNavigationGroups(language),
-    [language],
+    () => getSidebarNavigationGroups(language, roleIds),
+    [language, roleIds],
   )
 
   const activeGroupKey = React.useMemo(
@@ -279,7 +283,7 @@ const AdminSidebar: React.FC<AdminSidebarProps> = ({
           {!collapsed && (
             <button
               type='button'
-              onClick={() => handleNavigate(DEFAULT_HOME_ROUTE)}
+              onClick={() => handleNavigate(resolveHomeRoute(roleIds))}
               className='group flex min-w-0 flex-1 items-center gap-2.5 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent'
               aria-label='Thuê Nhà Trọ Admin'
             >

--- a/src/components/organisms/premium/MembershipTable.tsx
+++ b/src/components/organisms/premium/MembershipTable.tsx
@@ -13,6 +13,8 @@ interface MembershipTableProps {
   onEdit: (id: string) => void
   onDelete: (id: string) => void
   onToggleStatus: (id: string, currentStatus: string) => void
+  // When false, edit / delete actions and the status toggle are read-only.
+  canWrite?: boolean
 }
 
 export const MembershipTable: React.FC<MembershipTableProps> = ({
@@ -22,6 +24,7 @@ export const MembershipTable: React.FC<MembershipTableProps> = ({
   onEdit,
   onDelete,
   onToggleStatus,
+  canWrite = true,
 }) => {
   const t = useTranslations('premium')
 
@@ -107,11 +110,14 @@ export const MembershipTable: React.FC<MembershipTableProps> = ({
       render: (_, pkg) => {
         const isActive = pkg.status === 'active'
         return (
-          <label className='relative inline-flex cursor-pointer items-center'>
+          <label
+            className={`relative inline-flex items-center ${canWrite ? 'cursor-pointer' : 'cursor-default'}`}
+          >
             <input
               type='checkbox'
               className='peer sr-only'
               checked={isActive}
+              disabled={!canWrite}
               onChange={() => onToggleStatus(pkg.id, pkg.status)}
             />
             <div
@@ -146,24 +152,28 @@ export const MembershipTable: React.FC<MembershipTableProps> = ({
           >
             <Eye className='h-4 w-4' />
           </Button>
-          <Button
-            variant='ghost'
-            size='sm'
-            className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
-            title={t('actions.edit')}
-            onClick={() => onEdit(row.id)}
-          >
-            <Pencil className='h-4 w-4' />
-          </Button>
-          <Button
-            variant='ghost'
-            size='sm'
-            className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
-            title={t('actions.delete')}
-            onClick={() => onDelete(row.id)}
-          >
-            <Trash2 className='h-4 w-4' />
-          </Button>
+          {canWrite && (
+            <>
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
+                title={t('actions.edit')}
+                onClick={() => onEdit(row.id)}
+              >
+                <Pencil className='h-4 w-4' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='sm'
+                className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+                title={t('actions.delete')}
+                onClick={() => onDelete(row.id)}
+              >
+                <Trash2 className='h-4 w-4' />
+              </Button>
+            </>
+          )}
         </div>
       )}
     />

--- a/src/components/organisms/users/UserTable.tsx
+++ b/src/components/organisms/users/UserTable.tsx
@@ -24,6 +24,9 @@ interface UserTableProps {
   onRemoveBroker: (user: UserProfile) => void
   onClearMembership: (user: UserProfile) => void
   toolbarActions?: React.ReactNode
+  // When false, the row action column (edit / remove broker / clear membership /
+  // delete) is hidden for read-only roles. Defaults to true.
+  canWrite?: boolean
 }
 
 export const UserTable: React.FC<UserTableProps> = ({
@@ -37,6 +40,7 @@ export const UserTable: React.FC<UserTableProps> = ({
   onRemoveBroker,
   onClearMembership,
   toolbarActions,
+  canWrite = true,
 }) => {
   const t = useTranslations('admin.users')
 
@@ -153,60 +157,64 @@ export const UserTable: React.FC<UserTableProps> = ({
       loading={loading}
       emptyMessage={loading ? t('table.loading') : t('table.noUsersFound')}
       getRowKey={(row) => row.id}
-      actions={(row) => {
-        const user = users.find((u) => u.userId === row.id)
+      actions={
+        !canWrite
+          ? undefined
+          : (row) => {
+              const user = users.find((u) => u.userId === row.id)
 
-        return (
-          <div className='flex items-center justify-center gap-0.5'>
-            <Button
-              variant='ghost'
-              size='sm'
-              className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
-              title={t('table.actions.edit')}
-              onClick={() => {
-                if (user) onEdit(user)
-              }}
-            >
-              <Pencil className='h-4 w-4' />
-            </Button>
-            {user?.isBroker && (
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-8 w-8 p-0 text-muted-foreground hover:bg-warning/15 hover:text-warning-foreground'
-                title={t('table.actions.removeBroker')}
-                onClick={() => {
-                  if (user) onRemoveBroker(user)
-                }}
-              >
-                <UserX className='h-4 w-4' />
-              </Button>
-            )}
-            <Button
-              variant='ghost'
-              size='sm'
-              className='h-8 w-8 p-0 text-muted-foreground hover:bg-warning/15 hover:text-warning-foreground'
-              title={t('table.actions.clearMembership')}
-              onClick={() => {
-                if (user) onClearMembership(user)
-              }}
-            >
-              <ShieldOff className='h-4 w-4' />
-            </Button>
-            <Button
-              variant='ghost'
-              size='sm'
-              className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
-              title={t('table.actions.delete')}
-              onClick={() => {
-                if (user) onDelete(user)
-              }}
-            >
-              <Trash2 className='h-4 w-4' />
-            </Button>
-          </div>
-        )
-      }}
+              return (
+                <div className='flex items-center justify-center gap-0.5'>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
+                    title={t('table.actions.edit')}
+                    onClick={() => {
+                      if (user) onEdit(user)
+                    }}
+                  >
+                    <Pencil className='h-4 w-4' />
+                  </Button>
+                  {user?.isBroker && (
+                    <Button
+                      variant='ghost'
+                      size='sm'
+                      className='h-8 w-8 p-0 text-muted-foreground hover:bg-warning/15 hover:text-warning-foreground'
+                      title={t('table.actions.removeBroker')}
+                      onClick={() => {
+                        if (user) onRemoveBroker(user)
+                      }}
+                    >
+                      <UserX className='h-4 w-4' />
+                    </Button>
+                  )}
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0 text-muted-foreground hover:bg-warning/15 hover:text-warning-foreground'
+                    title={t('table.actions.clearMembership')}
+                    onClick={() => {
+                      if (user) onClearMembership(user)
+                    }}
+                  >
+                    <ShieldOff className='h-4 w-4' />
+                  </Button>
+                  <Button
+                    variant='ghost'
+                    size='sm'
+                    className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
+                    title={t('table.actions.delete')}
+                    onClick={() => {
+                      if (user) onDelete(user)
+                    }}
+                  >
+                    <Trash2 className='h-4 w-4' />
+                  </Button>
+                </div>
+              )
+            }
+      }
     />
   )
 }

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -14,7 +14,7 @@ type CategoryKey =
   | 'content'
   | 'moderation'
 
-type PageKey =
+export type PageKey =
   | 'users'
   | 'admins'
   | 'roles'
@@ -93,6 +93,93 @@ const CATEGORY_ROUTES: Record<CategoryKey, string[]> = {
   ],
   monetization: ['/monetization/membership', '/monetization/listing-types'],
 }
+
+// ── Role-based access control ──────────────────────────────────────────────
+// role_id values match the `role_id` column in the backend `roles` table.
+export const ROLE = {
+  SUPER_ADMIN: 'SA',
+  USER_ADMIN: 'UA',
+  CONTENT_MODERATOR: 'CM',
+  SUPPORT_ADMIN: 'SPA',
+  FINANCE_ADMIN: 'FA',
+  MARKETING_ADMIN: 'MA',
+} as const
+
+// The backend returns roles as role_NAME (e.g. "Super Admin") in the JWT `user`
+// claim, but access rules key off role_id. Normalize names → ids; pass unknown
+// values through untouched (already an id, or a role we don't gate on).
+const ROLE_NAME_TO_ID: Record<string, string> = {
+  'Super Admin': ROLE.SUPER_ADMIN,
+  'User Admin': ROLE.USER_ADMIN,
+  'Content Moderator': ROLE.CONTENT_MODERATOR,
+  'Support Admin': ROLE.SUPPORT_ADMIN,
+  'Finance Admin': ROLE.FINANCE_ADMIN,
+  'Marketing Admin': ROLE.MARKETING_ADMIN,
+}
+
+export const toRoleIds = (roles: string[] | undefined | null): string[] =>
+  (roles ?? []).map((role) => ROLE_NAME_TO_ID[role] ?? role)
+
+// Which role_ids may see each page. SA is granted everything via canAccessPage,
+// but is listed explicitly so the map reads as the source of truth.
+const PAGE_ROLES: Record<PageKey, string[]> = {
+  analyticsUsers: ['SA', 'UA', 'SPA', 'MA'],
+  analyticsPosts: ['SA', 'CM', 'MA'],
+  analyticsRevenue: ['SA', 'FA', 'MA'],
+  analyticsReports: ['SA', 'FA', 'MA'],
+  users: ['SA', 'UA', 'SPA'],
+  admins: ['SA', 'UA'],
+  roles: ['SA', 'UA'],
+  transactions: ['SA', 'SPA', 'FA'],
+  posts: ['SA', 'CM'],
+  news: ['SA', 'CM', 'MA'],
+  newsEditor: ['SA', 'CM', 'MA'],
+  reports: ['SA', 'CM', 'SPA'],
+  authors: ['SA', 'CM', 'SPA'],
+  brokerPending: ['SA', 'CM', 'SPA'],
+  premiumMembership: ['SA', 'SPA', 'FA', 'MA'],
+  premiumListingTypes: ['SA', 'FA', 'MA'],
+}
+
+export const canAccessPage = (page: PageKey, roleIds: string[]): boolean =>
+  roleIds.includes(ROLE.SUPER_ADMIN) ||
+  roleIds.some((role) => PAGE_ROLES[page].includes(role))
+
+// Roles allowed to perform mutating actions (create/edit/delete/toggle) on a
+// page. Only pages with a read-only (○) role differ from PAGE_ROLES; a page not
+// listed here lets every role that can see it also act. Mirrors the backend
+// @PreAuthorize on the mutating endpoints.
+const PAGE_WRITE_ROLES: Partial<Record<PageKey, string[]>> = {
+  roles: [ROLE.SUPER_ADMIN], // User Admin is read-only
+  users: [ROLE.SUPER_ADMIN, ROLE.USER_ADMIN], // Support Admin is read-only
+  premiumMembership: [
+    ROLE.SUPER_ADMIN,
+    ROLE.FINANCE_ADMIN,
+    ROLE.MARKETING_ADMIN,
+  ], // Support Admin is read-only
+}
+
+export const canWritePage = (page: PageKey, roleIds: string[]): boolean => {
+  if (roleIds.includes(ROLE.SUPER_ADMIN)) return true
+  const writeRoles = PAGE_WRITE_ROLES[page] ?? PAGE_ROLES[page]
+  return roleIds.some((role) => writeRoles.includes(role))
+}
+
+// First landing route the given roles can actually open. Used for post-login
+// redirect and the sidebar "home" link, since the static DEFAULT_HOME_ROUTE
+// (/insights/users) is off-limits to Content Moderator and Finance Admin.
+const HOME_ROUTE_PRIORITY = [
+  '/insights/users',
+  '/content/posts',
+  '/insights/revenue',
+  '/moderation/reports',
+  '/management/users',
+]
+
+export const resolveHomeRoute = (roleIds: string[]): string =>
+  HOME_ROUTE_PRIORITY.find((route) =>
+    canAccessPage(ROUTE_META[route].page, roleIds),
+  ) ?? DEFAULT_HOME_ROUTE
 
 type NavigationLabels = {
   home: string
@@ -183,6 +270,13 @@ const getMetaFromPath = (pathname: string) => {
   return exactPrefix ? ROUTE_META[exactPrefix] : undefined
 }
 
+// Whether the given roles may open the page a path belongs to. Unknown paths
+// (no ROUTE_META match) are treated as allowed so non-page routes aren't blocked.
+export const canAccessPath = (pathname: string, roleIds: string[]): boolean => {
+  const meta = getMetaFromPath(pathname)
+  return meta ? canAccessPage(meta.page, roleIds) : true
+}
+
 export const getBreadcrumbItems = (
   pathname: string,
   language: string,
@@ -261,20 +355,31 @@ export const getCategoryNavigation = (pathname: string, language: string) => {
   }
 }
 
-export const getSidebarNavigationGroups = (language: string) => {
+// When roleIds is omitted, every group/item is returned (unchanged behavior).
+// When provided, items the roles can't open are hidden and empty groups dropped.
+export const getSidebarNavigationGroups = (
+  language: string,
+  roleIds?: string[],
+) => {
   const locale = normalizeLanguage(language)
   const dictionary = LABELS[locale]
 
-  return (Object.keys(CATEGORY_ROUTES) as CategoryKey[]).map((categoryKey) => ({
-    key: categoryKey,
-    label: dictionary.categories[categoryKey],
-    items: CATEGORY_ROUTES[categoryKey].map((route) => {
-      const routeMeta = ROUTE_META[route]
-      return {
-        key: routeMeta.page,
-        href: route,
-        label: dictionary.pages[routeMeta.page],
-      }
-    }),
-  }))
+  return (Object.keys(CATEGORY_ROUTES) as CategoryKey[])
+    .map((categoryKey) => ({
+      key: categoryKey,
+      label: dictionary.categories[categoryKey],
+      items: CATEGORY_ROUTES[categoryKey]
+        .filter(
+          (route) => !roleIds || canAccessPage(ROUTE_META[route].page, roleIds),
+        )
+        .map((route) => {
+          const routeMeta = ROUTE_META[route]
+          return {
+            key: routeMeta.page,
+            href: route,
+            label: dictionary.pages[routeMeta.page],
+          }
+        }),
+    }))
+    .filter((group) => group.items.length > 0)
 }

--- a/src/hooks/usePermissions/index.ts
+++ b/src/hooks/usePermissions/index.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react'
+import { useAuthStore } from '@/store/auth/index.store'
+import { canWritePage, toRoleIds, type PageKey } from '@/constants/navigation'
+
+/**
+ * Whether the current admin's roles may perform mutating actions (create / edit
+ * / delete / toggle) on the given page. Use it to hide write-only controls for
+ * read-only roles; the backend still enforces the same rule on its endpoints.
+ */
+export const useCanWrite = (page: PageKey): boolean => {
+  const roles = useAuthStore((state) => state.user?.roles)
+  return useMemo(() => canWritePage(page, toRoleIds(roles)), [page, roles])
+}


### PR DESCRIPTION
## What
Adds role-based access control to the admin console for the 6-role model — **Super Admin (SA), User Admin (UA), Content Moderator (CM), Support Admin (SPA), Finance Admin (FA), Marketing Admin (MA)**. Previously every admin saw and could use every page.

## Access matrix
`✓` = full access · `○` = read-only (visible, no write actions) · blank = hidden

| Page | SA | UA | CM | SPA | FA | MA |
|---|:--:|:--:|:--:|:--:|:--:|:--:|
| Insights · Users | ✓ | ✓ | | ○ | | ✓ |
| Insights · Posts | ✓ | | ✓ | | | ✓ |
| Insights · Revenue | ✓ | | | | ✓ | ○ |
| Insights · Reports | ✓ | | | | ✓ | ✓ |
| Management · Users | ✓ | ✓ | | ○ | | |
| Management · Admins | ✓ | ✓ | | | | |
| Management · Roles | ✓ | ○ | | | | |
| Management · Transactions | ✓ | | | ○ | ✓ | |
| Content · Posts | ✓ | | ✓ | | | |
| Content · News | ✓ | | ✓ | | | ✓ |
| Moderation · Reports / Authors / Broker | ✓ | | ✓ | ✓ | | |
| Commerce · Membership | ✓ | | | ○ | ✓ | ✓ |
| Commerce · Listing Types | ✓ | | | | ✓ | ✓ |

## Changes
- `constants/navigation.ts`: `PAGE_ROLES` (view) + `PAGE_WRITE_ROLES` (mutate), `canAccessPage` / `canAccessPath` / `canWritePage`, `resolveHomeRoute`, and `toRoleIds` (normalizes the role_NAME the JWT returns into role_id).
- `adminSidebar`: hides groups/items a role can't open; logo + post-login redirect land on the first accessible page (the static `/insights/users` default is off-limits to CM and FA).
- `AppAdminLayout`: guards direct-URL access, redirecting to a permitted page.
- Read-only roles: create/edit/delete/toggle controls hidden on **roles**, **users**, and **membership** via the `useCanWrite` hook.

## Notes
- **Needs the companion backend PR** (`Vuhuydiet/smartrent-backend`) that enforces the same rules with `@PreAuthorize` — UI hiding alone is not security.
- Roles arrive in the JWT `user` claim as role_NAME and are mapped to role_id client-side.

## Testing
- `tsc --noEmit` and `eslint` pass.
- Manual per role: verify sidebar items, landing page, direct-URL block, and that read-only roles see no write buttons.