### PR TITLE
fix: author eligibility notice trusts server flag + total-report wording

### DIFF
--- a/src/components/organisms/authors/AuthorReportsDialog.tsx
+++ b/src/components/organisms/authors/AuthorReportsDialog.tsx
@@ -74,7 +74,9 @@ export const AuthorReportsDialog: React.FC<AuthorReportsDialogProps> = ({
 
   if (!author) return null
 
-  const eligible = author.resolvedReports > BLOCK_ELIGIBLE_THRESHOLD
+  // Trust the server-computed flag (based on TOTAL reports, any status) rather
+  // than recomputing client-side — avoids drift if the threshold ever changes.
+  const eligible = author.blockEligible
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -95,7 +97,7 @@ export const AuthorReportsDialog: React.FC<AuthorReportsDialogProps> = ({
               <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' />
               <span>
                 {t('reportsDialog.eligibleNotice', {
-                  count: author.resolvedReports,
+                  count: author.totalReports,
                   threshold: BLOCK_ELIGIBLE_THRESHOLD,
                 })}
               </span>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2452,7 +2452,7 @@
       "approved": "Approved",
       "listingPrefix": "Listing #",
       "adminNotes": "Admin notes",
-      "eligibleNotice": "This author has {count} approved reports (more than {threshold}) and is eligible to be blocked from posting.",
+      "eligibleNotice": "This author has {count} total reports (more than {threshold}) and is eligible to be blocked from posting.",
       "blockedNotice": "This author is currently blocked from posting."
     },
     "blockDialog": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2416,7 +2416,7 @@
       "approved": "Đã duyệt",
       "listingPrefix": "Tin #",
       "adminNotes": "Ghi chú admin",
-      "eligibleNotice": "Người này có {count} report đã duyệt (trên {threshold}), đủ điều kiện bị chặn đăng tin.",
+      "eligibleNotice": "Người này có tổng cộng {count} report (trên {threshold}), đủ điều kiện bị chặn đăng tin.",
       "blockedNotice": "Người này hiện đang bị chặn đăng tin."
     },
     "blockDialog": {


### PR DESCRIPTION
Use the server-computed blockEligible field instead of recomputing from resolvedReports client-side (avoids drift), and update the eligibility notice copy to reference total reports (matches the backend's ">3 total reports" threshold, not just admin-approved ones).