### PR TITLE
fix: block-eligibility notice reflects approved reports, not total

### DIFF
--- a/src/components/organisms/authors/AuthorReportsDialog.tsx
+++ b/src/components/organisms/authors/AuthorReportsDialog.tsx
@@ -74,8 +74,8 @@ export const AuthorReportsDialog: React.FC<AuthorReportsDialogProps> = ({
 
   if (!author) return null
 
-  // Trust the server-computed flag (based on TOTAL reports, any status) rather
-  // than recomputing client-side — avoids drift if the threshold ever changes.
+  // Trust the server-computed flag (based on RESOLVED / admin-approved reports)
+  // rather than recomputing client-side — avoids drift if the threshold ever changes.
   const eligible = author.blockEligible
 
   return (
@@ -97,7 +97,7 @@ export const AuthorReportsDialog: React.FC<AuthorReportsDialogProps> = ({
               <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' />
               <span>
                 {t('reportsDialog.eligibleNotice', {
-                  count: author.totalReports,
+                  count: author.resolvedReports,
                   threshold: BLOCK_ELIGIBLE_THRESHOLD,
                 })}
               </span>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2452,7 +2452,7 @@
       "approved": "Approved",
       "listingPrefix": "Listing #",
       "adminNotes": "Admin notes",
-      "eligibleNotice": "This author has {count} total reports (more than {threshold}) and is eligible to be blocked from posting.",
+      "eligibleNotice": "This author has {count} admin-approved reports (more than {threshold}) and is eligible to be blocked from posting.",
       "blockedNotice": "This author is currently blocked from posting."
     },
     "blockDialog": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2416,7 +2416,7 @@
       "approved": "Đã duyệt",
       "listingPrefix": "Tin #",
       "adminNotes": "Ghi chú admin",
-      "eligibleNotice": "Người này có tổng cộng {count} report (trên {threshold}), đủ điều kiện bị chặn đăng tin.",
+      "eligibleNotice": "Người này có {count} report đã được admin duyệt (trên {threshold}), đủ điều kiện bị chặn đăng tin.",
       "blockedNotice": "Người này hiện đang bị chặn đăng tin."
     },
     "blockDialog": {


### PR DESCRIPTION
A prior commit switched the eligibility notice/count to TOTAL reports, but the disabled-button hint ("Cần trên 3 report đã duyệt mới đủ điều kiện chặn") already says admin-approved reports — the two texts disagreed. Show/count resolvedReports here too, matching the backend fix that keys blockEligible off RESOLVED reports.