### PR TITLE
fix(auth): refresh admin session via admin refresh endpoint

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -5,6 +5,7 @@ export const PATHS = {
     LOGOUT: '/v1/auth/logout',
     REFRESH: '/v1/auth/refresh',
     ADMIN_LOGIN: '/v1/auth/admin',
+    ADMIN_REFRESH: '/v1/auth/admin/refresh',
     VERIFICATION: '/v1/verification',
     RE_SEND_VERIFICATION: '/v1/verification/code',
     INTROSPECT: '/v1/auth/introspect',

--- a/src/api/services/auth.service.ts
+++ b/src/api/services/auth.service.ts
@@ -72,6 +72,12 @@ export class AuthService {
 
   /**
    * Refresh authentication token
+   *
+   * This is an admin console: sessions are always issued via the admin login
+   * endpoint, so the refresh token's subject is an adminId. It MUST be refreshed
+   * through the admin refresh endpoint (which looks the subject up in the admin
+   * repository). Hitting the user refresh endpoint (/v1/auth/refresh) fails with
+   * USER_NOT_FOUND and silently logs the admin out when the access token expires.
    * @param refreshToken - Valid refresh token
    * @returns New authentication tokens
    */
@@ -80,7 +86,7 @@ export class AuthService {
   ): Promise<ApiResponse<AuthTokens>> {
     const response = await apiRequest<AuthTokens>({
       method: 'POST',
-      url: ENV.API.AUTH.REFRESH,
+      url: ENV.API.AUTH.ADMIN_REFRESH,
       data: { refreshToken },
       skipAuth: true,
     })


### PR DESCRIPTION
## Vấn đề
Session admin hết hạn sau đúng ~1 giờ (thời gian sống của access token) dù refresh token 24h vẫn còn hiệu lực → admin bị đá về màn login liên tục.

## Nguyên nhân gốc
- Admin đăng nhập qua `/v1/auth/admin`, nên `subject` của token là **adminId**.
- `AuthService.refreshToken` lại gọi `/v1/auth/refresh` — endpoint refresh của **user** — dùng `AuthenticationServiceImpl.refresh`, tra `userRepository.findById(adminId)` → không thấy → ném `USER_NOT_FOUND`.
- Refresh luôn fail → interceptor `clearAuthTokens()` + dispatch `auth:unauthorized` → logout. Auto-refresh **chưa bao giờ** hoạt động với admin.
- Backend đã có sẵn endpoint đúng `/v1/auth/admin/refresh` (tra `adminRepository`), chỉ là FE nối sai.

## Thay đổi
- Thêm hằng `ADMIN_REFRESH: '/v1/auth/admin/refresh'` trong `src/api/paths.ts`.
- `AuthService.refreshToken` trỏ sang `ENV.API.AUTH.ADMIN_REFRESH`.
- Mọi call site refresh (request/response interceptor, `useTokenRefresh`) đều đi qua method này nên một thay đổi vá toàn bộ luồng.

## Verify
- ✅ `tsc --noEmit` exit 0
- ✅ `eslint` 2 file đã sửa exit 0
- ✅ Contract khớp: FE gửi `{ refreshToken }` → BE `RefreshTokenRequest.refreshToken`; admin refresh trả `accessToken` + `refreshToken`.
- ⏳ Chưa test end-to-end trên môi trường chạy thật (cần backend + tài khoản admin).