### PR TITLE
feat(reports): add search + status filter to the reports table

### DIFF
--- a/src/components/organisms/reports/ReportTable.tsx
+++ b/src/components/organisms/reports/ReportTable.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
-import { DataTable, Column } from '@/components/organisms/DataTable'
+import { DataTable, Column, FilterConfig } from '@/components/organisms/DataTable'
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
 import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
@@ -48,6 +48,47 @@ export const ReportTable: React.FC<ReportTableProps> = ({
   onReview,
 }) => {
   const t = useTranslations('reports')
+
+  // Build a combined, searchable string per row. The DataTable frontend filter
+  // matches a single field (item[filter.id]) via case-insensitive substring, so
+  // we expose `searchIndex` to let one search box match reporter name, phone,
+  // report id or listing id at once.
+  const searchableData = React.useMemo<
+    (ListingReport & { searchIndex: string })[]
+  >(
+    () =>
+      data.map((report) => ({
+        ...report,
+        searchIndex: [
+          report.reporterName,
+          report.reporterPhone,
+          report.reportId,
+          report.listingId,
+        ]
+          .filter((value) => value !== undefined && value !== null && value !== '')
+          .join(' '),
+      })),
+    [data],
+  )
+
+  const filters: FilterConfig[] = [
+    {
+      id: 'searchIndex',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
+      id: 'status',
+      type: 'select',
+      label: t('filters.statusAll'),
+      options: [
+        { value: 'PENDING', label: t('statuses.pending') },
+        { value: 'RESOLVED', label: t('statuses.resolved') },
+        { value: 'REJECTED', label: t('statuses.dismissed') },
+      ],
+    },
+  ]
 
   const columns: Column<ListingReport>[] = [
     {
@@ -168,5 +209,12 @@ export const ReportTable: React.FC<ReportTableProps> = ({
     },
   ]
 
-  return <DataTable columns={columns} data={data} loading={loading} />
+  return (
+    <DataTable<ListingReport>
+      columns={columns}
+      data={searchableData}
+      filters={filters}
+      loading={loading}
+    />
+  )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2007,6 +2007,10 @@
       "wrong_information": "Wrong Information",
       "other": "Other"
     },
+    "filters": {
+      "searchPlaceholder": "Search by reporter, phone, or report ID…",
+      "statusAll": "All statuses"
+    },
     "statuses": {
       "pending": "Pending",
       "resolved": "Resolved",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1971,6 +1971,10 @@
       "wrong_information": "Thông Tin Sai",
       "other": "Khác"
     },
+    "filters": {
+      "searchPlaceholder": "Tìm theo người báo cáo, SĐT, mã tin…",
+      "statusAll": "Tất cả trạng thái"
+    },
     "statuses": {
       "pending": "Chờ Xử Lý",
       "resolved": "Đã Xử Lý",


### PR DESCRIPTION
## Bối cảnh
Bảng Báo cáo vi phạm (moderation/reports) trước đây **không có filter nào** — người duyệt phải cuộn tay để tìm báo cáo cụ thể hoặc lọc các báo cáo PENDING.

## Thay đổi (FE-only)
Thêm toolbar filter cho `DataTable` sẵn có trong `ReportTable`:
- **Ô search** khớp *tên người báo cáo + SĐT + mã báo cáo + mã tin đăng* qua một field tổng hợp `searchIndex` (cơ chế filter frontend của DataTable match theo 1 field, nên gom thành 1 chuỗi tìm kiếm).
- **Select lọc trạng thái**: Tất cả / Chờ xử lý / Đã xử lý / Đã bỏ qua (gắn field `status`).
- Dùng `filterMode='frontend'` mặc định → DataTable tự lo lọc, nút "Xóa tất cả", reset trang. **Không** đụng `reports-page.tsx` hay backend.

Phạm vi search là ~50 dòng đã tải sẵn (đúng bằng hành vi hiển thị hiện tại của bảng).

## i18n
Thêm `reports.filters.{searchPlaceholder,statusAll}` vào `vi.json` + `en.json`; nhãn trạng thái tái dùng `reports.statuses.*`.

## Files
- `src/components/organisms/reports/ReportTable.tsx`
- `src/messages/vi.json`, `src/messages/en.json`

## Verify
- ✅ `tsc --noEmit` exit 0
- ✅ `eslint` exit 0
- ✅ JSON hợp lệ, key mới có ở cả 2 locale
- ⏳ Chưa chạy live UI (cần dev server + backend + login admin)