### PR TITLE
feat(users): visible quick-search bar on the users table

### DIFF
--- a/src/components/features/users/users-page.tsx
+++ b/src/components/features/users/users-page.tsx
@@ -65,6 +65,20 @@ const UserManagement = () => {
       if (filterValues.isBroker) {
         filterArray.push(`isBroker:${filterValues.isBroker}`)
       }
+      // Visible quick-search box (id 'keyword'): fan the term out across
+      // name/email/phone. The backend OR-combines these search filters, so this
+      // becomes a single "match any of these fields" search.
+      if (filterValues.keyword) {
+        const kw = String(filterValues.keyword).trim()
+        if (kw) {
+          filterArray.push(
+            `firstName:${kw}`,
+            `lastName:${kw}`,
+            `email:${kw}`,
+            `phoneNumber:${kw}`,
+          )
+        }
+      }
 
       const response = await getUserList({
         page: filterValues.page ? Number(filterValues.page) : 1,

--- a/src/components/organisms/DataTable/TableFilters.tsx
+++ b/src/components/organisms/DataTable/TableFilters.tsx
@@ -1,10 +1,51 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { Input } from '@/components/atoms/input'
 import { Button } from '@/components/atoms/button'
 import { Search, X } from 'lucide-react'
 import { FilterDialog } from './FilterDialog'
 import type { TableFiltersProps, FilterConfig } from './types'
+
+// Debounced search input. Keeps a local value and only pushes it upstream after
+// a short pause, so API-mode tables don't refetch on every keystroke. Re-syncs
+// when the external value changes (e.g. cleared via the filter dialog or reset).
+function SearchFilterInput({
+  filter,
+  value,
+  onChange,
+}: {
+  filter: FilterConfig
+  value: string
+  onChange: (value: string) => void
+}) {
+  const [local, setLocal] = useState(value)
+
+  // Re-sync when the value changes from outside (clear/reset).
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+
+  // Debounce pushing the typed value upstream. The `local === value` guard makes
+  // the mount and re-sync runs no-ops, so only real typing schedules a change.
+  useEffect(() => {
+    if (local === value) return
+    const id = setTimeout(() => onChange(local), 300)
+    return () => clearTimeout(id)
+  }, [local])
+
+  return (
+    <div className='relative flex-1 min-w-[200px]'>
+      <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
+      <Input
+        type='text'
+        placeholder={filter.placeholder || filter.label}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        className={`w-full pl-10 ${filter.className || ''}`}
+      />
+    </div>
+  )
+}
 
 export function TableFilters({
   filters,
@@ -17,7 +58,10 @@ export function TableFilters({
 
   if (!filters || filters.length === 0) return null
 
-  // Check if there are filter fields meant for FilterDialog
+  // Inline filters render directly in the toolbar (e.g. a visible search box);
+  // isFilterField filters are collected into the "Bộ lọc" dialog. A table can
+  // use either or both.
+  const inlineFilters = filters.filter((f) => !f.isFilterField)
   const filterDialogFilters = filters.filter((f) => f.isFilterField)
   const hasFilterDialog = filterDialogFilters.length > 0
 
@@ -29,27 +73,29 @@ export function TableFilters({
     )
   })
 
-  // If we have FilterDialog filters, show only the FilterDialog
-  if (hasFilterDialog) {
-    return (
-      <FilterDialog
-        filterConfig={filterDialogFilters}
-        currentFilters={values}
-        onFilterChange={(newFilters) => {
-          if (onChangeMultiple) {
-            onChangeMultiple(newFilters)
-          } else {
-            Object.entries(newFilters).forEach(([key, value]) => {
-              onChange(key, value)
-            })
-          }
-        }}
-        onClear={() => onClear?.()}
-      />
-    )
+  // When applying dialog filters, preserve the inline filter values (e.g. the
+  // search box). FilterDialog only returns its own configured fields and the
+  // DataTable replaces the whole filter set, which would otherwise drop the
+  // inline search term.
+  const applyDialogFilters = (newFilters: Record<string, unknown>) => {
+    const preserved: Record<string, unknown> = {}
+    inlineFilters.forEach((f) => {
+      const v = values[f.id]
+      if (v !== undefined && v !== null && v !== '') {
+        preserved[f.id] = v
+      }
+    })
+    const merged = { ...preserved, ...newFilters }
+
+    if (onChangeMultiple) {
+      onChangeMultiple(merged)
+    } else {
+      Object.entries(merged).forEach(([key, value]) => {
+        onChange(key, value)
+      })
+    }
   }
 
-  // Original filter rendering for backward compatibility
   const renderFilter = (filter: FilterConfig) => {
     const value = Object.prototype.hasOwnProperty.call(values, filter.id)
       ? values[filter.id]
@@ -69,19 +115,15 @@ export function TableFilters({
       )
     }
 
-    // Search filter
+    // Search filter (debounced)
     if (filter.type === 'search') {
       return (
-        <div key={filter.id} className='relative flex-1 min-w-[200px]'>
-          <Search className='absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
-          <Input
-            type='text'
-            placeholder={filter.placeholder || filter.label}
-            value={stringValue}
-            onChange={(e) => onChange(filter.id, e.target.value)}
-            className={`w-full pl-10 ${filter.className || ''}`}
-          />
-        </div>
+        <SearchFilterInput
+          key={filter.id}
+          filter={filter}
+          value={stringValue}
+          onChange={(newValue) => onChange(filter.id, newValue)}
+        />
       )
     }
 
@@ -151,9 +193,18 @@ export function TableFilters({
 
   return (
     <div className='flex flex-col flex-wrap items-stretch gap-2 sm:flex-row sm:items-center'>
-      {filters.map((filter) => renderFilter(filter))}
+      {inlineFilters.map((filter) => renderFilter(filter))}
 
-      {hasActiveFilters && onClear && (
+      {hasFilterDialog && (
+        <FilterDialog
+          filterConfig={filterDialogFilters}
+          currentFilters={values}
+          onFilterChange={applyDialogFilters}
+          onClear={() => onClear?.()}
+        />
+      )}
+
+      {!hasFilterDialog && hasActiveFilters && onClear && (
         <Button
           variant='ghost'
           size='sm'

--- a/src/components/organisms/users/UserTable.tsx
+++ b/src/components/organisms/users/UserTable.tsx
@@ -102,6 +102,14 @@ export const UserTable: React.FC<UserTableProps> = ({
 
   const filterConfig: FilterConfig[] = [
     {
+      // Visible quick-search: mapped in users-page to firstName/lastName/email/
+      // phoneNumber, which the backend OR-combines into one search.
+      id: 'keyword',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
       id: 'firstName',
       type: 'search',
       label: t('filters.firstName'),

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -940,6 +940,7 @@
         "placeholder": "Search by name or user ID..."
       },
       "filters": {
+        "searchPlaceholder": "Search by name, email, or phone…",
         "allUsers": "All Users",
         "broker": "Broker",
         "normalUser": "Normal User",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -904,6 +904,7 @@
         "placeholder": "Tìm kiếm theo tên hoặc ID người dùng..."
       },
       "filters": {
+        "searchPlaceholder": "Tìm theo tên, email, SĐT…",
         "allUsers": "Tất Cả Người Dùng",
         "broker": "Môi giới",
         "normalUser": "Người dùng thường",


### PR DESCRIPTION
## Bối cảnh
Các bảng server-side (Người dùng, v.v.) chỉ để search **bên trong nút "Bộ lọc"**, nên nhìn vào trang không thấy ô search nào. PR này thêm một **ô search hiện rõ** ngay trên trang Người dùng, vẫn giữ "Bộ lọc" cho lọc nâng cao. Đây là bước 1 (Users trước), sẽ nhân rộng sang các bảng khác ở PR sau.

## Cách hoạt động
Backend `/v1/users/list` không có param `keyword`, nhưng **OR-combine** các filter search (firstName/lastName/email/phone) với LIKE ([UserServiceImpl.java:183](https://github.com/Shungisme/smartrent-backend)). Ô quick-search gửi cùng một giá trị cho cả 4 field → backend tự thành combined search "khớp bất kỳ field nào". **Không cần sửa backend.**

## Thay đổi
**`TableFilters` (component chung):**
- Render filter inline (không `isFilterField`) **+** nút "Bộ lọc" cùng lúc, thay vì loại trừ nhau. Backward-compatible: bảng chỉ-dialog giữ nguyên (Admins/News/Posts/Authors/Transactions/Roles đều 100% `isFilterField`), bảng chỉ-inline (Reports) giữ nguyên.
- **Debounce** ô search 300ms → api-mode không gọi API mỗi phím; tự re-sync khi clear/reset.
- **Giữ giá trị inline khi Apply dialog** (dialog thay toàn bộ filter set, nếu không sẽ mất từ khoá search).

**Bảng Users:**
- Thêm field search inline `keyword`; users-page fan-out sang firstName/lastName/email/phoneNumber.

## Files
- `src/components/organisms/DataTable/TableFilters.tsx`
- `src/components/organisms/users/UserTable.tsx`
- `src/components/features/users/users-page.tsx`
- `src/messages/vi.json`, `src/messages/en.json`

## Verify
- ✅ `tsc --noEmit` exit 0
- ✅ `eslint` các file đổi exit 0 (không warning)
- ✅ JSON hợp lệ, key mới ở cả 2 locale
- ✅ Kiểm tra không regression: tất cả bảng api-mode hiện có 100% filter `isFilterField` → `inlineFilters` rỗng → giao diện không đổi
- ✅ Trace tương tác: gõ search → debounce → OR-combine; Apply "Bộ lọc" giữ nguyên từ khoá; clear đồng bộ ô search
- ⏳ Chưa chạy live UI (cần dev server + backend + login admin)

## Bước tiếp theo (PR sau)
Nhân rộng ô quick-search sang Admins, Giao dịch, Tin tức, Tin đăng, Người đăng tin (mỗi bảng map vào field search backend riêng).