### PR TITLE
feat(admin): roll out visible quick-search to remaining tables

### DIFF
--- a/src/components/features/admins/admins-page.tsx
+++ b/src/components/features/admins/admins-page.tsx
@@ -60,6 +60,19 @@ const AdminManagement = () => {
             : filterValues.role
           filterArray.push(`role:${roleValue}`)
         }
+        // Visible quick-search box (id 'keyword'): fan the term out across
+        // name/email/phone. The backend OR-combines these search filters.
+        if (filterValues.keyword) {
+          const kw = String(filterValues.keyword).trim()
+          if (kw) {
+            filterArray.push(
+              `firstName:${kw}`,
+              `lastName:${kw}`,
+              `email:${kw}`,
+              `phoneNumber:${kw}`,
+            )
+          }
+        }
 
         const response = await getAdminList({
           page: filterValues.page ? Number(filterValues.page) : 1,

--- a/src/components/features/news/news-page.tsx
+++ b/src/components/features/news/news-page.tsx
@@ -77,6 +77,14 @@ const NewsManagement = () => {
       if (filterValues.tag) {
         filterArray.push(`tag:${filterValues.tag}`)
       }
+      // Visible quick-search box (id 'keyword'): map to the `title` key, which
+      // the backend matches against title OR summary.
+      if (filterValues.keyword) {
+        const kw = String(filterValues.keyword).trim()
+        if (kw) {
+          filterArray.push(`title:${kw}`)
+        }
+      }
 
       const apiFilters: NewsFilterRequest = {
         page: filterValues.page ? Number(filterValues.page) : 1,

--- a/src/components/organisms/admins/AdminTable.tsx
+++ b/src/components/organisms/admins/AdminTable.tsx
@@ -64,6 +64,14 @@ export const AdminTable: React.FC<AdminTableProps> = ({
 
   const filterConfig: FilterConfig[] = [
     {
+      // Visible quick-search: mapped in admins-page to firstName/lastName/email/
+      // phoneNumber, which the backend OR-combines into one search.
+      id: 'keyword',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
       id: 'firstName',
       type: 'search',
       label: t('filters.firstName'),

--- a/src/components/organisms/authors/AuthorTable.tsx
+++ b/src/components/organisms/authors/AuthorTable.tsx
@@ -117,17 +117,19 @@ export const AuthorTable: React.FC<AuthorTableProps> = ({
 
   const filterConfig: FilterConfig[] = [
     {
+      // Visible quick-search mapped to the `name` param, which the backend
+      // OR-matches against first + last name. email/phone stay in the dialog —
+      // the backend AND-combines them, so they can't share one search box.
+      id: 'name',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
       id: 'email',
       type: 'search',
       label: t('table.headers.email'),
       placeholder: t('filters.emailPlaceholder'),
-      isFilterField: true,
-    },
-    {
-      id: 'name',
-      type: 'search',
-      label: t('table.headers.author'),
-      placeholder: t('filters.namePlaceholder'),
       isFilterField: true,
     },
     {

--- a/src/components/organisms/news/NewsTable.tsx
+++ b/src/components/organisms/news/NewsTable.tsx
@@ -199,6 +199,14 @@ export const NewsTable: React.FC<NewsTableProps> = ({
 
   const filterConfig: FilterConfig[] = [
     {
+      // Visible quick-search mapped in news-page to the `title` key, which the
+      // backend matches against title OR summary.
+      id: 'keyword',
+      type: 'search',
+      label: t('filters.search'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
       id: 'title',
       type: 'search',
       label: t('filters.title'),

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -213,6 +213,14 @@ export const PostTable: React.FC<PostTableProps> = ({
 
   const filters: FilterConfig[] = [
     {
+      // Visible quick-search mapped (via mapUIFiltersToAPI) to the backend
+      // `keyword` FULLTEXT search across title, address and description.
+      id: 'keyword',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+    {
       id: 'title',
       type: 'search',
       label: t('filters.titleSearch'),

--- a/src/components/organisms/transactions/AdminTransactionTable.tsx
+++ b/src/components/organisms/transactions/AdminTransactionTable.tsx
@@ -159,6 +159,14 @@ export const AdminTransactionTable = ({
 
   const filterConfig: FilterConfig[] = [
     {
+      // Visible quick-search mapped to the backend `q` param, which OR-searches
+      // transaction/gateway/reference/invoice codes and order info.
+      id: 'q',
+      type: 'search',
+      label: t('filters.search'),
+      placeholder: t('filters.search'),
+    },
+    {
       id: 'transactionId',
       type: 'search',
       label: t('filters.transactionId'),
@@ -222,6 +230,7 @@ export const AdminTransactionTable = ({
       filters={filterConfig}
       filterMode='api'
       filterValues={{
+        q: filters.q ?? '',
         transactionId: filters.transactionId ?? '',
         customer: filters.customer ?? '',
         status: filters.status ?? '',
@@ -234,6 +243,7 @@ export const AdminTransactionTable = ({
       onFilterChange={(next) =>
         onFiltersChange({
           ...filters,
+          q: (next.q as string) || undefined,
           transactionId: (next.transactionId as string) || undefined,
           customer: (next.customer as string) || undefined,
           status: (next.status as PaymentStatus) || undefined,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1303,6 +1303,7 @@
         "placeholder": "Search by name, ID or email..."
       },
       "filters": {
+        "searchPlaceholder": "Search by name, email, or phone…",
         "allRoles": "All Roles",
         "SA": "Super Admin",
         "UA": "User Admin",
@@ -1711,6 +1712,7 @@
       "placeholder": "Search by title, poster name, or address..."
     },
     "filters": {
+      "searchPlaceholder": "Search by title, address, or description…",
       "status": "Status",
       "pending": "Pending",
       "approved": "Approved",
@@ -2474,6 +2476,7 @@
       "blockError": "Failed to update posting block. Please try again."
     },
     "filters": {
+      "searchPlaceholder": "Search authors by name…",
       "emailPlaceholder": "Search by email",
       "namePlaceholder": "Search by name",
       "phonePlaceholder": "Search by phone",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1267,6 +1267,7 @@
         "placeholder": "Tìm kiếm theo tên, ID hoặc email..."
       },
       "filters": {
+        "searchPlaceholder": "Tìm theo tên, email, SĐT…",
         "allRoles": "Tất Cả Vai Trò",
         "SA": "Super Admin",
         "UA": "User Admin",
@@ -1675,6 +1676,7 @@
       "placeholder": "Tìm theo tiêu đề, tên người đăng hoặc địa chỉ..."
     },
     "filters": {
+      "searchPlaceholder": "Tìm theo tiêu đề, địa chỉ, mô tả…",
       "status": "Trạng Thái",
       "pending": "Chờ Duyệt",
       "approved": "Đã Duyệt",
@@ -2438,6 +2440,7 @@
       "blockError": "Cập nhật chặn đăng tin thất bại. Vui lòng thử lại."
     },
     "filters": {
+      "searchPlaceholder": "Tìm người đăng tin theo tên…",
       "emailPlaceholder": "Tìm theo email",
       "namePlaceholder": "Tìm theo tên",
       "phonePlaceholder": "Tìm theo SĐT",


### PR DESCRIPTION
Tiếp nối #88 (Users): thêm **ô search hiện rõ** cho các bảng server-side còn lại, vẫn giữ "Bộ lọc" cho lọc nâng cao. Mỗi bảng map quick-search vào đúng thứ backend hỗ trợ — **không sửa backend**.

| Bảng | id ô search | Map tới backend | Tìm được |
|---|---|---|---|
| **Admins** | `keyword` | fan-out → firstName/lastName/email/phoneNumber (BE OR-combine) | tên, email, SĐT |
| **Transactions** | `q` | param `q` có sẵn (service đã gửi) | mã GD / cổng / reference / hoá đơn / order info |
| **News** | `keyword` | map `title:` (BE OR title+summary) | tiêu đề, tóm tắt |
| **Posts** | `keyword` | FULLTEXT `keyword` (mapUIFiltersToAPI đã forward) | tiêu đề, địa chỉ, mô tả |
| **Authors** | `name` | param `name` (BE OR first+last name) | tên người đăng |

Ghi chú:
- **Authors** không có combined search (BE AND-combine email/name/phone), nên ô search map vào `name` (đã OR first+last) — trường rộng nhất; field `name` chuyển từ dialog ra ô hiện rõ, email/phone/blockEligible vẫn ở "Bộ lọc".
- **Transactions/News** tái dùng key i18n có sẵn; **Admins/Posts/Authors** thêm `filters.searchPlaceholder`.
- Component chung `TableFilters` đã có sẵn hỗ trợ inline + dialog + debounce từ #88.

## Files
- Organisms: AdminTable, AdminTransactionTable, NewsTable, PostTable, AuthorTable
- Pages: admins-page, news-page (fan-out/map keyword)
- i18n: vi.json, en.json

## Verify
- ✅ `tsc --noEmit` exit 0
- ✅ `eslint` các file đổi exit 0
- ✅ JSON hợp lệ, mọi key có ở cả 2 locale
- ✅ Wiring từng bảng map đúng cơ chế backend (đã kiểm tra FE + backend cho từng bảng)
- ⏳ Chưa chạy live UI (cần dev server + backend + login admin)

Sau PR này, các bảng server-side còn lại đều có ô search hiện rõ. Còn skip: broker-pending (BE chưa có param search), membership + listing-types (list cấu hình nhỏ).