### PR TITLE
fix: show rejected vs temporarily-hidden as distinct statuses in admi…

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -223,6 +223,12 @@ export interface AdminListingSummary {
   revisionCount: number | null
   lastModerationReasonCode: string | null
   lastModerationReasonText: string | null
+  /**
+   * True when moderationStatus=SUSPENDED came from rejecting the listing in
+   * the review queue (creates an owner action). False/absent when it came
+   * from temporarily hiding the listing during report review instead.
+   */
+  hasPendingOwnerAction?: boolean | null
 }
 
 // Statistics for Admin Dashboard

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -79,6 +79,7 @@ export const PostTable: React.FC<PostTableProps> = ({
       rejected: t('statuses.rejected'),
       revision_required: t('statuses.revision_required'),
       suspended: t('statuses.suspended'),
+      hidden: t('statuses.hidden'),
       expired: t('statuses.expired'),
       pending_payment: t('statuses.pending_payment'),
     }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1913,6 +1913,7 @@
       "rejected": "Rejected",
       "revision_required": "Revision Required",
       "suspended": "Suspended",
+      "hidden": "Temporarily Hidden",
       "expired": "Expired",
       "pending_payment": "Pending Payment"
     },

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1877,6 +1877,7 @@
       "rejected": "Từ Chối",
       "revision_required": "Cần Chỉnh Sửa",
       "suspended": "Tạm Ngưng",
+      "hidden": "Đang Ẩn Tạm Thời",
       "expired": "Hết Hạn",
       "pending_payment": "Chờ Thanh Toán"
     },

--- a/src/types/posts.type.ts
+++ b/src/types/posts.type.ts
@@ -7,6 +7,7 @@ export type PostStatus =
   | 'rejected'
   | 'revision_required'
   | 'suspended'
+  | 'hidden'
   | 'expired'
   | 'pending_payment'
 

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -107,6 +107,7 @@ export const getStatusColor = (status: PostStatus): string => {
     rejected: 'border-destructive/30 bg-destructive/10 text-destructive',
     revision_required: 'border-orange-500/30 bg-orange-500/10 text-orange-700',
     suspended: 'border-destructive/30 bg-destructive/10 text-destructive',
+    hidden: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
     expired: 'border-border bg-muted text-foreground/70',
     pending_payment: 'border-purple-500/30 bg-purple-500/10 text-purple-700',
   }
@@ -285,6 +286,11 @@ const deriveStatusFromListingStatus = (
   moderationStatus: ModerationStatus | null | undefined,
   verificationStatus: string | null | undefined,
   expired: boolean | null | undefined,
+  // moderationStatus=SUSPENDED is shared by two unrelated admin actions:
+  // rejecting a listing in the review queue (always creates an owner
+  // action) and temporarily hiding a listing under report review (never
+  // does). Split on that signal instead of showing both as "suspended".
+  hasPendingOwnerAction?: boolean | null,
 ): PostStatus => {
   switch (listingStatus) {
     case 'EXPIRED':
@@ -301,7 +307,9 @@ const deriveStatusFromListingStatus = (
       return 'approved'
     case 'REJECTED':
       if (moderationStatus === 'REVISION_REQUIRED') return 'revision_required'
-      if (moderationStatus === 'SUSPENDED') return 'suspended'
+      if (moderationStatus === 'SUSPENDED') {
+        return hasPendingOwnerAction ? 'rejected' : 'hidden'
+      }
       return 'rejected'
     default:
       return deriveStatusFromVerification(verificationStatus, expired)
@@ -361,6 +369,7 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
       item.moderationStatus,
       item.adminVerification?.verificationStatus,
       item.expired,
+      item.hasPendingOwnerAction,
     ),
     verified: item.verified ?? false,
     isVerify: false,


### PR DESCRIPTION
…n table

moderationStatus=SUSPENDED is set by two different admin actions: rejecting a listing in the review queue (always creates an owner action) and temporarily hiding a listing under report review (never does). The admin table showed both as a generic "Tạm Ngưng" (suspended) badge, so clicking reject in the review queue looked identical to a report-driven hide.

- AdminListingSummary now carries hasPendingOwnerAction (backend already exposes it, see smartrent-backend fix/admin-listing-owner-action-signal)
- deriveStatusFromListingStatus branches SUSPENDED on that signal: has a pending owner action -> 'rejected', otherwise -> new 'hidden' status
- PostTable/post.utils get labels + a color for 'hidden'; en/vi strings added

The moderationStatus=SUSPENDED filter option in the status dropdown still queries both cases together (backend has no separate filter param for this yet) — only the per-row badge is disambiguated by this change.