### PR TITLE
fix: rename the hide-only filter tab label to "Đang Ẩn Tạm Thời"

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1696,7 +1696,7 @@
       "rejected": "Rejected",
       "revisionRequired": "Revision Required",
       "suspendedRejected": "Rejected (Admin)",
-      "suspended": "Suspended",
+      "suspended": "Temporarily Hidden",
       "resubmitted": "Resubmitted"
     },
     "stats": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1660,7 +1660,7 @@
       "rejected": "Đã Từ Chối",
       "revisionRequired": "Cần Sửa",
       "suspendedRejected": "Đã Từ Chối (Admin)",
-      "suspended": "Tạm Ngưng",
+      "suspended": "Đang Ẩn Tạm Thời",
       "resubmitted": "Đã Gửi Lại"
     },
     "stats": {


### PR DESCRIPTION
Now that the SUSPENDED status is split into SUSPENDED_REJECTED / SUSPENDED_HIDDEN tabs, tabs.suspended is only ever used for the report-driven-hide case — "Tạm Ngưng" was ambiguous with the rejected case it used to also cover, name it for what it actually filters.