### PR TITLE
refactor: drive admin post statuses off distinct moderation statuses

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -26,6 +26,7 @@ export type ModerationStatus =
   | 'REVISION_REQUIRED'
   | 'SUSPENDED'
   | 'RESUBMITTED'
+  | 'REMOVED'
 
 // Decision for moderation action
 export type ModerationDecision =
@@ -223,12 +224,6 @@ export interface AdminListingSummary {
   revisionCount: number | null
   lastModerationReasonCode: string | null
   lastModerationReasonText: string | null
-  /**
-   * True when moderationStatus=SUSPENDED came from rejecting the listing in
-   * the review queue (creates an owner action). False/absent when it came
-   * from temporarily hiding the listing during report review instead.
-   */
-  hasPendingOwnerAction?: boolean | null
 }
 
 // Statistics for Admin Dashboard
@@ -269,13 +264,6 @@ export interface ListingFilterRequest {
   /** Matches owner firstName/lastName/contactPhoneNumber/phoneNumber (case-insensitive contains). */
   ownerSearch?: string
   moderationStatus?: ModerationStatus
-  /**
-   * Only meaningful alongside moderationStatus=SUSPENDED, which is shared by
-   * rejecting a listing in the review queue (creates a pending owner action)
-   * and temporarily hiding it under report review (doesn't). true narrows to
-   * the reject case, false narrows to the hide case.
-   */
-  hasPendingOwnerAction?: boolean
   listingStatus?: SummaryListingStatus
   verified?: boolean
   isVerify?: boolean

--- a/src/components/organisms/posts/PostReviewModal.tsx
+++ b/src/components/organisms/posts/PostReviewModal.tsx
@@ -153,9 +153,15 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
   const _getStatusLabel = (status: string) => {
     const labels: Record<string, string> = {
       pending: t('statuses.pending'),
+      resubmitted: t('statuses.resubmitted'),
       approved: t('statuses.approved'),
       rejected: t('statuses.rejected'),
+      revision_required: t('statuses.revision_required'),
+      suspended: t('statuses.suspended'),
+      hidden: t('statuses.hidden'),
+      removed: t('statuses.removed'),
       expired: t('statuses.expired'),
+      pending_payment: t('statuses.pending_payment'),
     }
     return labels[status] || status
   }

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -80,6 +80,7 @@ export const PostTable: React.FC<PostTableProps> = ({
       revision_required: t('statuses.revision_required'),
       suspended: t('statuses.suspended'),
       hidden: t('statuses.hidden'),
+      removed: t('statuses.removed'),
       expired: t('statuses.expired'),
       pending_payment: t('statuses.pending_payment'),
     }
@@ -256,8 +257,8 @@ export const PostTable: React.FC<PostTableProps> = ({
         { value: 'APPROVED', label: t('tabs.approved') },
         { value: 'REJECTED', label: t('tabs.rejected') },
         { value: 'REVISION_REQUIRED', label: t('tabs.revisionRequired') },
-        { value: 'SUSPENDED_REJECTED', label: t('tabs.suspendedRejected') },
-        { value: 'SUSPENDED_HIDDEN', label: t('tabs.suspended') },
+        { value: 'SUSPENDED', label: t('tabs.suspended') },
+        { value: 'REMOVED', label: t('tabs.removed') },
         { value: 'RESUBMITTED', label: t('tabs.resubmitted') },
       ],
       isFilterField: true,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1695,8 +1695,8 @@
       "approved": "Approved",
       "rejected": "Rejected",
       "revisionRequired": "Revision Required",
-      "suspendedRejected": "Rejected (Admin)",
       "suspended": "Temporarily Hidden",
+      "removed": "Permanently Removed",
       "resubmitted": "Resubmitted"
     },
     "stats": {
@@ -1908,13 +1908,14 @@
       "unfurnished": "Unfurnished"
     },
     "statuses": {
-      "pending": "Pending",
+      "pending": "Pending Review",
       "resubmitted": "Resubmitted",
       "approved": "Approved",
       "rejected": "Rejected",
       "revision_required": "Revision Required",
-      "suspended": "Suspended",
+      "suspended": "Temporarily Hidden",
       "hidden": "Temporarily Hidden",
+      "removed": "Permanently Removed",
       "expired": "Expired",
       "pending_payment": "Pending Payment"
     },

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1657,10 +1657,10 @@
     "tabs": {
       "pendingReview": "Chờ Duyệt",
       "approved": "Đã Duyệt",
-      "rejected": "Đã Từ Chối",
+      "rejected": "Bị từ chối",
       "revisionRequired": "Cần Sửa",
-      "suspendedRejected": "Đã Từ Chối (Admin)",
-      "suspended": "Đang Ẩn Tạm Thời",
+      "suspended": "Đang ẩn tạm thời",
+      "removed": "Đã gỡ vĩnh viễn",
       "resubmitted": "Đã Gửi Lại"
     },
     "stats": {
@@ -1872,15 +1872,16 @@
       "unfurnished": "Chưa có nội thất"
     },
     "statuses": {
-      "pending": "Chờ Duyệt",
-      "resubmitted": "Đã Gửi Lại",
-      "approved": "Đã Duyệt",
-      "rejected": "Từ Chối",
-      "revision_required": "Cần Chỉnh Sửa",
-      "suspended": "Tạm Ngưng",
-      "hidden": "Đang Ẩn Tạm Thời",
-      "expired": "Hết Hạn",
-      "pending_payment": "Chờ Thanh Toán"
+      "pending": "Đang chờ duyệt",
+      "resubmitted": "Đã gửi lại",
+      "approved": "Đã duyệt",
+      "rejected": "Bị từ chối",
+      "revision_required": "Cần chỉnh sửa",
+      "suspended": "Đang ẩn tạm thời",
+      "hidden": "Đang ẩn tạm thời",
+      "removed": "Đã gỡ vĩnh viễn",
+      "expired": "Hết hạn",
+      "pending_payment": "Chờ thanh toán"
     },
     "toasts": {
       "loadListingsError": "Không thể tải danh sách tin đăng. Vui lòng thử lại.",

--- a/src/types/posts.type.ts
+++ b/src/types/posts.type.ts
@@ -8,6 +8,7 @@ export type PostStatus =
   | 'revision_required'
   | 'suspended'
   | 'hidden'
+  | 'removed'
   | 'expired'
   | 'pending_payment'
 

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -107,7 +107,8 @@ export const getStatusColor = (status: PostStatus): string => {
     rejected: 'border-destructive/30 bg-destructive/10 text-destructive',
     revision_required: 'border-orange-500/30 bg-orange-500/10 text-orange-700',
     suspended: 'border-destructive/30 bg-destructive/10 text-destructive',
-    hidden: 'border-amber-500/30 bg-amber-500/10 text-amber-700',
+    hidden: 'border-sky-500/30 bg-sky-500/10 text-sky-700',
+    removed: 'border-destructive/30 bg-destructive/10 text-destructive',
     expired: 'border-border bg-muted text-foreground/70',
     pending_payment: 'border-purple-500/30 bg-purple-500/10 text-purple-700',
   }
@@ -143,21 +144,11 @@ export const mapUIFiltersToAPI = (
   }
 
   // moderationStatus filter (primary moderation workflow field)
-  // Also send the corresponding listingStatus — mirrors smartrent-fe's LISTING_STATUS_MODERATION_MAP pattern
-  //
-  // 'SUSPENDED_REJECTED' / 'SUSPENDED_HIDDEN' are UI-only synthetic values (see
-  // PostTable's status filter options) — moderationStatus=SUSPENDED alone is shared
-  // by rejecting a listing in the review queue and temporarily hiding it under
-  // report review, so the dropdown splits it into two using hasPendingOwnerAction.
-  const rawModerationStatus = str('moderationStatus')
-  let moderationStatus = rawModerationStatus
-  if (rawModerationStatus === 'SUSPENDED_REJECTED') {
-    moderationStatus = 'SUSPENDED'
-    apiFilters.hasPendingOwnerAction = true
-  } else if (rawModerationStatus === 'SUSPENDED_HIDDEN') {
-    moderationStatus = 'SUSPENDED'
-    apiFilters.hasPendingOwnerAction = false
-  }
+  // Also send the corresponding listingStatus — mirrors smartrent-fe's LISTING_STATUS_MODERATION_MAP pattern.
+  // Every value is a real ModerationStatus now (REJECTED / SUSPENDED / REMOVED are
+  // distinct), so the same status sent from here and from smartrent-fe hits the
+  // same backend filter and returns the same rows.
+  const moderationStatus = str('moderationStatus')
   if (moderationStatus) {
     apiFilters.moderationStatus = moderationStatus as ModerationStatus
     const moderationToListingStatus: Partial<
@@ -169,6 +160,7 @@ export const mapUIFiltersToAPI = (
       REVISION_REQUIRED: 'REJECTED',
       SUSPENDED: 'REJECTED',
       REJECTED: 'REJECTED',
+      REMOVED: 'REJECTED',
     }
     const mappedListingStatus =
       moderationToListingStatus[moderationStatus as ModerationStatus]
@@ -294,16 +286,26 @@ const deriveStatusFromVerification = (
   }
 }
 
+// Map a raw ModerationStatus straight to the UI PostStatus. Used by the detail
+// modal (which carries moderationStatus but not the computed listingStatus) so
+// its image badge matches the table — and, in turn, matches smartrent-fe, which
+// labels the same statuses identically.
+const MODERATION_TO_POST_STATUS: Partial<Record<ModerationStatus, PostStatus>> =
+  {
+    PENDING_REVIEW: 'pending',
+    RESUBMITTED: 'resubmitted',
+    APPROVED: 'approved',
+    REVISION_REQUIRED: 'revision_required',
+    REJECTED: 'rejected',
+    SUSPENDED: 'hidden',
+    REMOVED: 'removed',
+  }
+
 const deriveStatusFromListingStatus = (
   listingStatus: SummaryListingStatus | null | undefined,
   moderationStatus: ModerationStatus | null | undefined,
   verificationStatus: string | null | undefined,
   expired: boolean | null | undefined,
-  // moderationStatus=SUSPENDED is shared by two unrelated admin actions:
-  // rejecting a listing in the review queue (always creates an owner
-  // action) and temporarily hiding a listing under report review (never
-  // does). Split on that signal instead of showing both as "suspended".
-  hasPendingOwnerAction?: boolean | null,
 ): PostStatus => {
   switch (listingStatus) {
     case 'EXPIRED':
@@ -319,10 +321,10 @@ const deriveStatusFromListingStatus = (
     case 'VERIFIED':
       return 'approved'
     case 'REJECTED':
+      // moderationStatus now carries the exact outcome — no owner-action lookup.
       if (moderationStatus === 'REVISION_REQUIRED') return 'revision_required'
-      if (moderationStatus === 'SUSPENDED') {
-        return hasPendingOwnerAction ? 'rejected' : 'hidden'
-      }
+      if (moderationStatus === 'SUSPENDED') return 'hidden'
+      if (moderationStatus === 'REMOVED') return 'removed'
       return 'rejected'
     default:
       return deriveStatusFromVerification(verificationStatus, expired)
@@ -382,7 +384,6 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
       item.moderationStatus,
       item.adminVerification?.verificationStatus,
       item.expired,
-      item.hasPendingOwnerAction,
     ),
     verified: item.verified ?? false,
     isVerify: false,
@@ -427,10 +428,13 @@ export const mapDetailToUI = (item: ListingResponseWithAdmin): UIPostData => {
     postedDate: date,
     postedTime: time,
     expiryDate,
-    status: deriveStatusFromVerification(
-      item.adminVerification?.verificationStatus,
-      item.expired,
-    ),
+    status:
+      (item.moderationStatus &&
+        MODERATION_TO_POST_STATUS[item.moderationStatus]) ||
+      deriveStatusFromVerification(
+        item.adminVerification?.verificationStatus,
+        item.expired,
+      ),
     verified: item.verified,
     isVerify: item.isVerify,
     rejectionReason: item.adminVerification?.rejectionReason,


### PR DESCRIPTION
Backend now returns REJECTED / SUSPENDED / REMOVED as distinct moderationStatus values instead of overloading SUSPENDED + hasPendingOwnerAction. Consume that directly and align labels with smartrent-fe so the same status reads and filters identically on both apps:

- ModerationStatus type gains REMOVED; PostStatus gains 'removed'
- deriveStatusFromListingStatus branches on moderationStatus alone (REJECTED→rejected, SUSPENDED→hidden, REMOVED→removed) — dropped the hasPendingOwnerAction argument
- mapDetailToUI (the review modal image badge) now derives from moderationStatus via MODERATION_TO_POST_STATUS, so the badge shows the real state instead of the verification-only fallback
- PostReviewModal._getStatusLabel covers every status now
- status filter dropdown sends real statuses (SUSPENDED / REMOVED) instead of the synthetic SUSPENDED_REJECTED/SUSPENDED_HIDDEN — so filtering by a status here returns the same rows as smartrent-fe filtering the same one
- dropped hasPendingOwnerAction from AdminListingSummary / ListingFilterRequest
- statuses/tabs i18n now match smartrent-fe: Bị từ chối / Đang ẩn tạm thời / Đã gỡ vĩnh viễn (en: Rejected / Temporarily Hidden / Permanently Removed)