### PR TITLE
fix: correct admin moderation-action success handling and hide/unhide…

### DIFF
--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -17,6 +17,9 @@ import { PostTable } from '@/components/organisms/posts/PostTable'
 import { PostReviewModal } from '@/components/organisms/posts/PostReviewModal'
 import { AiSchedulerControl } from '@/components/molecules/aiServiceStatus/AiSchedulerControl'
 
+// Backend success envelope code (see constants/env API_RESPONSE_CODES.SUCCESS).
+const SUCCESS_CODE = '999999'
+
 const PostVerification = () => {
   const t = useTranslations('posts')
   const [posts, setPosts] = useState<UIPostData[]>([])
@@ -114,12 +117,13 @@ const PostVerification = () => {
       setActionLoading(true)
       const response = await ListingService.approveListing(selectedPost.id)
 
-      if (response && response.code !== '9999') {
+      if (response.success && response.code === SUCCESS_CODE) {
         toast.success(t('toasts.approveSuccess'))
-
-        await fetchListings()
+        // Close the dialog immediately, then refresh the table in the
+        // background — don't leave the modal open during the refetch.
         setReviewModalOpen(false)
         setSelectedPost(null)
+        await fetchListings()
       } else {
         const errorMessage = response.message || t('toasts.approveError')
         toast.error(errorMessage)
@@ -152,12 +156,11 @@ const PostVerification = () => {
         deadline.toISOString(),
       )
 
-      if (response && response.code !== '9999') {
+      if (response.success && response.code === SUCCESS_CODE) {
         toast.success(t('toasts.rejectSuccess'))
-
-        await fetchListings()
         setReviewModalOpen(false)
         setSelectedPost(null)
+        await fetchListings()
       } else {
         const errorMessage = response.message || t('toasts.rejectError')
         toast.error(errorMessage)
@@ -186,12 +189,11 @@ const PostVerification = () => {
         true,
       )
 
-      if (response && response.code !== '9999') {
+      if (response.success && response.code === SUCCESS_CODE) {
         toast.success(t('toasts.revisionSuccess'))
-
-        await fetchListings()
         setReviewModalOpen(false)
         setSelectedPost(null)
+        await fetchListings()
       } else {
         const errorMessage = response.message || t('toasts.revisionError')
         toast.error(errorMessage)

--- a/src/components/organisms/reports/ReportReviewModal.tsx
+++ b/src/components/organisms/reports/ReportReviewModal.tsx
@@ -150,11 +150,15 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
 
     try {
       setActionLoading(true)
-      await ListingService.resolveReport(report.reportId, {
+      const response = await ListingService.resolveReport(report.reportId, {
         status: 'RESOLVED',
         adminNotes: actionReason,
         removeListing: true,
       })
+      if (!response.success) {
+        toast.error(response.message || t('toasts.removeListingError'))
+        return
+      }
       toast.success(t('toasts.removeListingSuccess'))
       onOpenChange(false)
       onActionComplete()
@@ -176,10 +180,14 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
 
     try {
       setActionLoading(true)
-      await ListingService.resolveReport(report.reportId, {
+      const response = await ListingService.resolveReport(report.reportId, {
         status: 'REJECTED',
         adminNotes: actionReason,
       })
+      if (!response.success) {
+        toast.error(response.message || t('toasts.dismissError'))
+        return
+      }
       toast.success(t('toasts.dismissSuccess'))
       onOpenChange(false)
       onActionComplete()
@@ -195,7 +203,14 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
     if (!report) return
     try {
       setVisibilityLoading(true)
-      await ListingService.hideListing(report.listingId, t('review.hideReason'))
+      const response = await ListingService.hideListing(
+        report.listingId,
+        t('review.hideReason'),
+      )
+      if (!response.success) {
+        toast.error(response.message || t('toasts.hideError'))
+        return
+      }
       toast.success(t('toasts.hideSuccess'))
       await fetchListingDetails(report.listingId)
       onActionComplete()
@@ -211,7 +226,11 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
     if (!report) return
     try {
       setVisibilityLoading(true)
-      await ListingService.unhideListing(report.listingId)
+      const response = await ListingService.unhideListing(report.listingId)
+      if (!response.success) {
+        toast.error(response.message || t('toasts.unhideError'))
+        return
+      }
       toast.success(t('toasts.unhideSuccess'))
       await fetchListingDetails(report.listingId)
       onActionComplete()
@@ -635,37 +654,39 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                 </div>
               )}
               <div className='flex flex-col gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end'>
-                {/* Temporary hide / unhide — opposite toggle, kept apart on the left */}
-                {listingDetails &&
-                  (listingDetails.moderationStatus === 'SUSPENDED' ? (
-                    <Button
-                      onClick={handleUnhideListing}
-                      disabled={visibilityLoading}
-                      variant='outline'
-                      className='text-sm sm:mr-auto'
-                    >
-                      {visibilityLoading ? (
-                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                      ) : (
-                        <Eye className='mr-2 h-4 w-4' />
-                      )}
-                      {t('review.unhide')}
-                    </Button>
-                  ) : (
-                    <Button
-                      onClick={handleHideListing}
-                      disabled={visibilityLoading}
-                      variant='outline'
-                      className='border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground text-sm sm:mr-auto'
-                    >
-                      {visibilityLoading ? (
-                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                      ) : (
-                        <EyeOff className='mr-2 h-4 w-4' />
-                      )}
-                      {t('review.hide')}
-                    </Button>
-                  ))}
+                {/* Temporary hide / unhide — only meaningful for a live listing
+                    (Hide) or one already hidden under this review (Unhide).
+                    A rejected/removed listing is terminal, so neither shows. */}
+                {listingDetails?.moderationStatus === 'SUSPENDED' && (
+                  <Button
+                    onClick={handleUnhideListing}
+                    disabled={visibilityLoading}
+                    variant='outline'
+                    className='text-sm sm:mr-auto'
+                  >
+                    {visibilityLoading ? (
+                      <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                    ) : (
+                      <Eye className='mr-2 h-4 w-4' />
+                    )}
+                    {t('review.unhide')}
+                  </Button>
+                )}
+                {listingDetails?.moderationStatus === 'APPROVED' && (
+                  <Button
+                    onClick={handleHideListing}
+                    disabled={visibilityLoading}
+                    variant='outline'
+                    className='border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground text-sm sm:mr-auto'
+                  >
+                    {visibilityLoading ? (
+                      <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                    ) : (
+                      <EyeOff className='mr-2 h-4 w-4' />
+                    )}
+                    {t('review.hide')}
+                  </Button>
+                )}
                 {report.status === 'PENDING' && (
                   <>
                     {onRequestRevision && (


### PR DESCRIPTION
… gating

The post review handlers checked response.code !== '9999' — a typo for the '999999' success code — so every response (including API errors) took the success branch, and the modal only closed after the follow-up refetch finished. Result: a failed action still showed a success toast, and the dialog appeared to "stay open" during the refetch.

- approve/reject/requestRevision now gate on response.success && response.code === '999999', close the dialog immediately, then refetch in the background
- the report-review hide/unhide/remove/dismiss handlers awaited the service without checking response.success (apiRequest never throws — it returns success:false), so failures showed success too; they now check it and surface the real error
- the report modal's hide/unhide toggle showed a "Hide" button for any non-SUSPENDED listing, including rejected/removed ones; now Hide shows only for APPROVED (live) listings and Unhide only for SUSPENDED