### PR TITLE
feat(posts): show AI duplicate-check result in manual review

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -102,6 +102,7 @@ export const PATHS = {
   // AI listing verification endpoints (Spring Boot -> Python AI service)
   AI_VERIFICATION: {
     VERIFY: '/v1/ai/listings/verify', // POST run AI moderation on a listing payload
+    CHECK_DUPLICATE: '/v1/ai/listings/:listingId/check-duplicate', // POST run AI duplicate check for an existing listing
     SERVICE_STATUS: '/v1/ai/listings/service-status', // GET Python AI service reachability
     SCHEDULER_STATUS: '/v1/ai/listings/scheduler/status', // GET auto-moderation cronjob enabled state (admin)
     SCHEDULER_TOGGLE: '/v1/ai/listings/scheduler/toggle', // PUT enable/disable auto-moderation scheduler (admin)

--- a/src/api/services/ai-verification.service.ts
+++ b/src/api/services/ai-verification.service.ts
@@ -3,6 +3,7 @@ import { PATHS } from '@/api/paths'
 import {
   AiVerificationRequest,
   AiVerificationResult,
+  AiDuplicateCheckResult,
   AiServiceStatus,
   AiSchedulerStatus,
   ApiResponse,
@@ -34,6 +35,26 @@ export class AiVerificationService {
       url: PATHS.AI_VERIFICATION.VERIFY,
       data: payload,
       // AI multimodal analysis can take ~20-30s; override the default timeout.
+      timeout: 60000,
+    })
+  }
+
+  /**
+   * Run the AI duplicate-detection pipeline for an existing listing by ID.
+   * POST /v1/ai/listings/:listingId/check-duplicate
+   *
+   * Stateless: persists nothing. Returns the decision (PASS/SUSPICIOUS/DUPLICATE),
+   * highest similarity score, and matched listings for the admin to review.
+   *
+   * @param listingId - ID of the listing to check
+   */
+  static async checkDuplicate(
+    listingId: string,
+  ): Promise<ApiResponse<AiDuplicateCheckResult>> {
+    return apiRequest<AiDuplicateCheckResult>({
+      method: 'POST',
+      url: PATHS.AI_VERIFICATION.CHECK_DUPLICATE.replace(':listingId', listingId),
+      // Candidate retrieval + LLM + image hashing can take a while.
       timeout: 60000,
     })
   }

--- a/src/api/types/ai-verification.type.ts
+++ b/src/api/types/ai-verification.type.ts
@@ -134,6 +134,35 @@ export interface AiVerificationResult {
 }
 
 // ---------------------------------------------------------------------------
+// Response data for POST /v1/ai/listings/{listingId}/check-duplicate
+//
+// NOTE: unlike the snake_case Python verification payload, the duplicate result
+// is a Spring Boot DTO (DuplicateCheckResponse) and comes back camelCase.
+// ---------------------------------------------------------------------------
+
+export type AiDuplicateDecision = 'PASS' | 'SUSPICIOUS' | 'DUPLICATE'
+
+export interface AiDuplicateMatch {
+  listingId: number | string | null
+  title: string
+  score: number
+  titleSimilarity: number
+  descriptionSimilarity: number
+  addressSimilarity: number
+  priceSimilarity: number
+  imageSimilarity: number
+  llmScore: number | null
+  llmReason: string | null
+}
+
+export interface AiDuplicateCheckResult {
+  isDuplicate: boolean
+  highestScore: number
+  decision: AiDuplicateDecision
+  suspiciousMatches: AiDuplicateMatch[]
+}
+
+// ---------------------------------------------------------------------------
 // Response data for GET /v1/ai/listings/service-status
 // ---------------------------------------------------------------------------
 

--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -9,6 +9,7 @@ import {
   Lightbulb,
   CheckCircle2,
   XCircle,
+  Files,
 } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
@@ -17,6 +18,8 @@ import { UIPostData } from '@/types/posts.type'
 import { AiVerificationService } from '@/api/services/ai-verification.service'
 import {
   AiVerificationResult,
+  AiDuplicateCheckResult,
+  AiDuplicateDecision,
   AiSeverity,
   AiPriority,
 } from '@/api/types/ai-verification.type'
@@ -102,12 +105,14 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
   const t = useTranslations('posts')
   const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<AiVerificationResult | null>(null)
+  const [duplicate, setDuplicate] = useState<AiDuplicateCheckResult | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [serviceAvailable, setServiceAvailable] = useState<boolean | null>(null)
 
   // Reset whenever the modal closes or the selected post changes.
   useEffect(() => {
     setResult(null)
+    setDuplicate(null)
     setError(null)
     setLoading(false)
   }, [post, open])
@@ -117,13 +122,33 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
     setLoading(true)
     setError(null)
     setResult(null)
+    setDuplicate(null)
     try {
       const payload = buildAiVerificationRequest(post)
-      const res = await AiVerificationService.verifyListing(payload)
-      if (res.success && res.data) {
-        setResult(res.data)
+      // Run verification + duplicate check concurrently. Each is independent:
+      // a duplicate-check failure is silent (advisory), while a verify failure
+      // surfaces the error banner.
+      const [verifyRes, dupRes] = await Promise.allSettled([
+        AiVerificationService.verifyListing(payload),
+        AiVerificationService.checkDuplicate(post.id),
+      ])
+
+      if (
+        verifyRes.status === 'fulfilled' &&
+        verifyRes.value.success &&
+        verifyRes.value.data
+      ) {
+        setResult(verifyRes.value.data)
       } else {
-        setError(res.message || t('aiAnalysis.error'))
+        setError(t('aiAnalysis.error'))
+      }
+
+      if (
+        dupRes.status === 'fulfilled' &&
+        dupRes.value.success &&
+        dupRes.value.data
+      ) {
+        setDuplicate(dupRes.value.data)
       }
     } catch {
       setError(t('aiAnalysis.error'))
@@ -131,6 +156,13 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
       setLoading(false)
     }
   }
+
+  const duplicateDecisionColor = (decision: AiDuplicateDecision) =>
+    decision === 'DUPLICATE'
+      ? 'bg-destructive/10 text-destructive dark:bg-destructive/20 border-destructive/30'
+      : decision === 'SUSPICIOUS'
+        ? 'bg-warning/10 text-warning-foreground dark:bg-warning/20 border-warning/30'
+        : 'bg-success/10 text-success-foreground dark:bg-success/20 border-success/30'
 
   if (!post) return null
 
@@ -452,6 +484,75 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                   </div>
                 ))}
               </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Duplicate detection — independent of the verify result */}
+      {duplicate && !loading && (
+        <div className='mt-4 rounded-xl border border-border/70 bg-card p-4'>
+          <div className='flex flex-wrap items-center justify-between gap-2'>
+            <div className='flex items-center gap-2'>
+              <Files className='h-4 w-4 text-primary' />
+              <span className='text-sm font-semibold text-foreground'>
+                {t('aiAnalysis.duplicate.title')}
+              </span>
+            </div>
+            <div className='flex items-center gap-2'>
+              <Badge
+                variant='outline'
+                className={cn(
+                  'text-xs',
+                  duplicateDecisionColor(duplicate.decision),
+                )}
+              >
+                {t(`aiAnalysis.duplicate.decision.${duplicate.decision}`)}
+              </Badge>
+              <span className='text-xs text-muted-foreground'>
+                {t('aiAnalysis.duplicate.highestScore')}:{' '}
+                <span className='font-semibold'>
+                  {toPercent(duplicate.highestScore)}%
+                </span>
+              </span>
+            </div>
+          </div>
+
+          {duplicate.suspiciousMatches.length === 0 ? (
+            <p className='mt-2 text-sm text-muted-foreground'>
+              {t('aiAnalysis.duplicate.none')}
+            </p>
+          ) : (
+            <div className='mt-3 space-y-2'>
+              {duplicate.suspiciousMatches.map((m, i) => (
+                <div key={i} className='rounded-lg border border-border/70 p-3'>
+                  <div className='flex items-center justify-between gap-2'>
+                    <span className='line-clamp-1 text-sm font-medium text-foreground'>
+                      {m.title || `#${m.listingId}`}
+                    </span>
+                    <Badge variant='outline' className='text-xs'>
+                      {toPercent(m.score)}%
+                    </Badge>
+                  </div>
+                  <div className='mt-1 text-[11px] text-muted-foreground'>
+                    #{m.listingId} · {t('aiAnalysis.duplicate.image')}:{' '}
+                    <span className='font-semibold'>
+                      {toPercent(m.imageSimilarity)}%
+                    </span>{' '}
+                    · {t('aiAnalysis.duplicate.text')}:{' '}
+                    {toPercent(m.descriptionSimilarity)}% ·{' '}
+                    {t('aiAnalysis.duplicate.address')}:{' '}
+                    {toPercent(m.addressSimilarity)}% ·{' '}
+                    {t('aiAnalysis.duplicate.price')}:{' '}
+                    {toPercent(m.priceSimilarity)}%
+                  </div>
+                  {m.llmReason && (
+                    <p className='mt-1 text-xs text-foreground/80'>
+                      {m.llmReason}
+                    </p>
+                  )}
+                </div>
+              ))}
             </div>
           )}
         </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1872,6 +1872,20 @@
         "watermark": "Watermark / phone",
         "stockPhoto": "Stock photo"
       },
+      "duplicate": {
+        "title": "Duplicate check",
+        "highestScore": "Highest score",
+        "none": "No similar listings found.",
+        "image": "Image",
+        "text": "Content",
+        "address": "Address",
+        "price": "Price",
+        "decision": {
+          "PASS": "No match",
+          "SUSPICIOUS": "Suspicious",
+          "DUPLICATE": "Duplicate"
+        }
+      },
       "level": {
         "low": "Low",
         "medium": "Medium",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1836,6 +1836,20 @@
         "watermark": "Watermark / SĐT",
         "stockPhoto": "Ảnh mẫu"
       },
+      "duplicate": {
+        "title": "Kiểm tra trùng lặp",
+        "highestScore": "Điểm cao nhất",
+        "none": "Không phát hiện tin tương tự.",
+        "image": "Ảnh",
+        "text": "Nội dung",
+        "address": "Địa chỉ",
+        "price": "Giá",
+        "decision": {
+          "PASS": "Không trùng",
+          "SUSPICIOUS": "Nghi ngờ",
+          "DUPLICATE": "Trùng lặp"
+        }
+      },
       "level": {
         "low": "Thấp",
         "medium": "Trung bình",


### PR DESCRIPTION
The admin AI analysis panel only ran verification (content/image/video/completeness); the duplicate-detection result was never surfaced. This runs it alongside the verify analysis on the same button and renders a dedicated card. Needs the backend PR (Vuhuydiet/smartrent-backend: feat/admin-duplicate-check-ui).

## What changed
- **service/types**: `AiVerificationService.checkDuplicate(listingId)` → `POST /v1/ai/listings/:listingId/check-duplicate`, `AiDuplicateCheckResult` (camelCase — Spring DTO).
- **PostAiAnalysis**: fire verify + duplicate concurrently (`Promise.allSettled` — a duplicate failure is silent, verify errors still surface). New **"Duplicate check"** card: decision badge (PASS/SUSPICIOUS/DUPLICATE, colored), highest score, and per-match title/id with image/text/address/price similarity % + LLM reason.
- **i18n**: `aiAnalysis.duplicate.*` (vi + en).

## Notes
- `tsc --noEmit` + eslint clean. Manually tested end-to-end by the author.