### PR TITLE
refactor(posts): two-column review dialog to cut AI-feedback scrolling

### DIFF
--- a/docs/superpowers/specs/2026-07-14-review-modal-two-column-design.md
+++ b/docs/superpowers/specs/2026-07-14-review-modal-two-column-design.md
@@ -1,0 +1,64 @@
+# Post Review Modal — Two-Column Layout
+
+**Date:** 2026-07-14
+**Repo:** `admin/smartrent-fe`
+**Status:** Design approved, pending implementation
+
+## Problem
+
+The admin listing-review dialog (`PostReviewModal`) is a single tall scroll column
+inside a 1200px-wide dialog. The AI analysis panel (`PostAiAnalysis`, now including
+the duplicate-check card) sits near the bottom, after Hero → Images → Details →
+Location → Description → Amenities → Poster. To read the AI feedback the admin
+scrolls all the way down, then scrolls back up to re-check the listing while
+deciding — a lot of up/down. The dialog's horizontal space is wasted.
+
+## Goal / Non-goals
+
+**Goal:** stop the up/down scrolling by showing the AI feedback beside the listing.
+**Non-goals:** changing any section's content/logic, the image lightbox, the
+`PostAiAnalysis` component itself, or the action buttons. This is layout-only.
+
+## Design
+
+Restructure only the body of `PostReviewModal.tsx` (header + sticky footer
+unchanged). Content splits into two columns for pending listings:
+
+- **`lg` and up (desktop):** two independently-scrolling columns. Outer container
+  `overflow-hidden`; each column `lg:overflow-y-auto`.
+  - Left `lg:flex-1` + right border: Hero, Images, Property details, Location,
+    Description, Amenities, Poster.
+  - Right `lg:w-[440px] lg:shrink-0`: `PostAiAnalysis` then the two moderation
+    textareas (verification notes + rejection reason).
+  - Scrolling the AI panel never moves the listing, and vice versa.
+- **Below `lg` (mobile/tablet):** single vertical scroll (columns stack: listing,
+  then AI, then form) — the current behavior. Admin review is desktop-first.
+
+Container pattern:
+```
+<div className="flex min-h-0 flex-1 flex-col overflow-y-auto lg:flex-row lg:overflow-hidden">
+  <div className="... lg:flex-1 lg:overflow-y-auto lg:border-r border-border/60"> {/* listing */}
+  <div className="... lg:w-[440px] lg:shrink-0 lg:overflow-y-auto">              {/* AI + form */}
+</div>
+```
+
+**Reviewed (not pending):** no AI panel and no moderation form, so keep the current
+single-column view (read-only verification notes / rejection reason below the
+listing). Avoids an empty right column.
+
+## Error handling / edge cases
+
+- Description keeps its own `max-h-60` inner scroll — nested inside the left
+  column's scroll, which is fine.
+- Empty AI/form states already handled by `PostAiAnalysis` and the existing
+  conditionals; no new states.
+
+## Verification
+
+- `tsc --noEmit` + `eslint` on the changed file.
+- Manual: open a pending listing, confirm two panes scroll independently on
+  desktop and stack on mobile.
+
+## Files touched
+
+`src/components/organisms/posts/PostReviewModal.tsx` (layout only).

--- a/src/components/organisms/posts/PostReviewModal.tsx
+++ b/src/components/organisms/posts/PostReviewModal.tsx
@@ -271,8 +271,20 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
             </DialogTitle>
           </DialogHeader>
 
-          <div className='min-h-0 flex-1 overflow-y-auto px-6 py-5'>
-            <div className='space-y-5'>
+          <div
+            className={cn(
+              'flex min-h-0 flex-1 flex-col overflow-y-auto',
+              isPending && 'lg:flex-row lg:overflow-hidden',
+            )}
+          >
+            {/* Left column — listing details */}
+            <div
+              className={cn(
+                'space-y-5 px-6 py-5',
+                isPending &&
+                  'lg:flex-1 lg:overflow-y-auto lg:border-r lg:border-border/60',
+              )}
+            >
               {/* Hero: title, code, listing type, status & price */}
               <div className='rounded-xl border border-border/70 bg-gradient-to-br from-primary/5 via-card to-card p-5 shadow-sm md:p-6'>
                 <div className='flex items-start justify-between gap-4'>
@@ -467,11 +479,40 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
                 </div>
               </div>
 
-              {/* AI-assisted analysis (advisory only) */}
-              {isPending && <PostAiAnalysis post={selectedPost} open={open} />}
+              {/* Display existing notes if already reviewed (single-column view) */}
+              {!isPending && (
+                <>
+                  {selectedPost.verificationNotes && (
+                    <div>
+                      <SectionLabel icon={FileText}>
+                        {t('review.verificationNotes')}
+                      </SectionLabel>
+                      <div className='rounded-lg border border-border/70 bg-muted/30 p-4 text-sm text-muted-foreground'>
+                        {selectedPost.verificationNotes}
+                      </div>
+                    </div>
+                  )}
+                  {selectedPost.rejectionReason && (
+                    <div>
+                      <SectionLabel icon={XCircle}>
+                        {t('review.rejectionReason')}
+                      </SectionLabel>
+                      <div className='rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive'>
+                        {selectedPost.rejectionReason}
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
 
-              {/* Rejection Reason / Verification Notes */}
-              {isPending && (
+            {/* Right column — AI analysis + moderation form (pending only) */}
+            {isPending && (
+              <div className='space-y-5 px-6 py-5 lg:w-[440px] lg:shrink-0 lg:overflow-y-auto'>
+                {/* AI-assisted analysis (advisory only) */}
+                <PostAiAnalysis post={selectedPost} open={open} />
+
+                {/* Rejection Reason / Verification Notes */}
                 <div className='space-y-4 rounded-lg border border-border/70 bg-muted/30 p-4'>
                   <div>
                     <label
@@ -506,34 +547,8 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
                     />
                   </div>
                 </div>
-              )}
-
-              {/* Display existing notes if already reviewed */}
-              {!isPending && (
-                <>
-                  {selectedPost.verificationNotes && (
-                    <div>
-                      <SectionLabel icon={FileText}>
-                        {t('review.verificationNotes')}
-                      </SectionLabel>
-                      <div className='rounded-lg border border-border/70 bg-muted/30 p-4 text-sm text-muted-foreground'>
-                        {selectedPost.verificationNotes}
-                      </div>
-                    </div>
-                  )}
-                  {selectedPost.rejectionReason && (
-                    <div>
-                      <SectionLabel icon={XCircle}>
-                        {t('review.rejectionReason')}
-                      </SectionLabel>
-                      <div className='rounded-lg border border-destructive/40 bg-destructive/5 p-4 text-sm text-destructive'>
-                        {selectedPost.rejectionReason}
-                      </div>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
+              </div>
+            )}
           </div>
 
           {/* Action Buttons */}


### PR DESCRIPTION
The admin listing-review dialog was a single tall scroll column, so admins had to scroll to the bottom to read the AI analysis (now including the duplicate-check card) and back up to re-check the listing while deciding. This splits the body into two independently-scrolling columns on desktop.

## What changed (layout only — `PostReviewModal.tsx`)
- **`lg+` (pending listing):** left column = listing details (hero / images / facts / location / description / amenities / poster), right column (440px) = `PostAiAnalysis` + moderation form. Each scrolls on its own — scrolling the AI panel no longer moves the listing.
- **`< lg`:** single vertical scroll, columns stack — unchanged behavior.
- **Reviewed (not pending):** stays single-column (read-only notes) — no empty pane.

No section content/logic, image lightbox, or action buttons changed.

## Notes
- `tsc --noEmit` + eslint clean. Manually verified by the author.
- Independent of the duplicate-card PR (#100) — that PR doesn't touch this file.

Spec: `docs/superpowers/specs/2026-07-14-review-modal-two-column-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)