### PR TITLE
fix: show review actions and AI analysis for resubmitted listings

### DIFF
--- a/src/components/organisms/posts/PostReviewModal.tsx
+++ b/src/components/organisms/posts/PostReviewModal.tsx
@@ -248,7 +248,8 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
   const images = selectedPost.images ?? []
   const visibleImages = images.slice(0, MAX_VISIBLE_THUMBS)
   const hiddenCount = images.length - visibleImages.length
-  const isPending = selectedPost.status === 'pending'
+  const isPending =
+    selectedPost.status === 'pending' || selectedPost.status === 'resubmitted'
 
   return (
     <>


### PR DESCRIPTION
The review modal's isPending gate only matched status 'pending' (moderationStatus PENDING_REVIEW), so a resubmitted listing - which carries the distinct RESUBMITTED status - fell into the read-only "already reviewed" branch: no AI analysis panel, no approve/reject/ request-revision buttons, even though the backend re-queues it for AI verification and expects a normal review pass. Treat 'resubmitted' the same as 'pending'.