### PR TITLE
feat: add hide/unhide toggle to the post review modal

### DIFF
--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -29,6 +29,7 @@ const PostVerification = () => {
   const [reviewModalOpen, setReviewModalOpen] = useState(false)
   const [detailLoading, setDetailLoading] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
+  const [visibilityLoading, setVisibilityLoading] = useState(false)
   const [stats, setStats] = useState<ListingStatisticsSummary>({
     pendingVerification: 0,
     verified: 0,
@@ -213,6 +214,57 @@ const PostVerification = () => {
     }
   }
 
+  const handleHide = async () => {
+    if (!selectedPost) return
+
+    try {
+      setVisibilityLoading(true)
+      const response = await ListingService.hideListing(
+        selectedPost.id,
+        t('review.hideReason'),
+      )
+
+      if (response.success && response.code === SUCCESS_CODE) {
+        toast.success(t('toasts.hideSuccess'))
+        setReviewModalOpen(false)
+        setSelectedPost(null)
+        await fetchListings()
+      } else {
+        const errorMessage = response.message || t('toasts.hideError')
+        toast.error(errorMessage)
+      }
+    } catch (error) {
+      console.error('Error hiding listing:', error)
+      toast.error(t('toasts.hideError'))
+    } finally {
+      setVisibilityLoading(false)
+    }
+  }
+
+  const handleUnhide = async () => {
+    if (!selectedPost) return
+
+    try {
+      setVisibilityLoading(true)
+      const response = await ListingService.unhideListing(selectedPost.id)
+
+      if (response.success && response.code === SUCCESS_CODE) {
+        toast.success(t('toasts.unhideSuccess'))
+        setReviewModalOpen(false)
+        setSelectedPost(null)
+        await fetchListings()
+      } else {
+        const errorMessage = response.message || t('toasts.unhideError')
+        toast.error(errorMessage)
+      }
+    } catch (error) {
+      console.error('Error unhiding listing:', error)
+      toast.error(t('toasts.unhideError'))
+    } finally {
+      setVisibilityLoading(false)
+    }
+  }
+
   return (
     <div>
       {initialLoading ? (
@@ -244,7 +296,10 @@ const PostVerification = () => {
         onApprove={handleApprove}
         onReject={handleReject}
         onRequestRevision={handleRequestRevision}
+        onHide={handleHide}
+        onUnhide={handleUnhide}
         actionLoading={actionLoading}
+        visibilityLoading={visibilityLoading}
       />
     </div>
   )

--- a/src/components/organisms/posts/PostReviewModal.tsx
+++ b/src/components/organisms/posts/PostReviewModal.tsx
@@ -27,6 +27,8 @@ import {
   FileText,
   Sparkles,
   RotateCcw,
+  Eye,
+  EyeOff,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -51,7 +53,10 @@ interface PostReviewModalProps {
   onApprove: (notes: string) => void
   onReject: (reason: string) => void
   onRequestRevision: (reason: string) => void
+  onHide: () => void
+  onUnhide: () => void
   actionLoading: boolean
+  visibilityLoading: boolean
 }
 
 /** Consistent section heading with a leading accent icon. */
@@ -92,7 +97,10 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
   onApprove,
   onReject,
   onRequestRevision,
+  onHide,
+  onUnhide,
   actionLoading,
+  visibilityLoading,
 }) => {
   const t = useTranslations('posts')
   const [rejectionReason, setRejectionReason] = useState('')
@@ -250,6 +258,8 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
   const hiddenCount = images.length - visibleImages.length
   const isPending =
     selectedPost.status === 'pending' || selectedPost.status === 'resubmitted'
+  const isApproved = selectedPost.status === 'approved'
+  const isHidden = selectedPost.status === 'hidden'
 
   return (
     <>
@@ -553,46 +563,80 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
           </div>
 
           {/* Action Buttons */}
-          {isPending && (
+          {(isPending || isApproved || isHidden) && (
             <div className='shrink-0 border-t border-border/60 bg-card/95 px-6 py-4 backdrop-blur supports-[backdrop-filter]:bg-card/80'>
               <div className='flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end'>
-                <Button
-                  variant='outline'
-                  onClick={() => onRequestRevision(buildRejectionReason())}
-                  disabled={actionLoading}
-                  className='border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground'
-                >
-                  {actionLoading ? (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  ) : (
-                    <RotateCcw className='mr-2 h-4 w-4' />
-                  )}
-                  {t('review.requestRevisionButton')}
-                </Button>
-                <Button
-                  variant='outline'
-                  onClick={() => onReject(buildRejectionReason())}
-                  disabled={actionLoading}
-                  className='border-destructive/30 text-destructive hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive'
-                >
-                  {actionLoading ? (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  ) : (
-                    <XCircle className='mr-2 h-4 w-4' />
-                  )}
-                  {t('review.rejectButton')}
-                </Button>
-                <Button
-                  onClick={() => onApprove(verificationNotes)}
-                  disabled={actionLoading}
-                >
-                  {actionLoading ? (
-                    <Loader2 className='mr-2 h-4 w-4 animate-spin' />
-                  ) : (
-                    <CheckCircle className='mr-2 h-4 w-4' />
-                  )}
-                  {t('review.approveButton')}
-                </Button>
+                {isHidden && (
+                  <Button
+                    onClick={onUnhide}
+                    disabled={visibilityLoading}
+                    variant='outline'
+                    className='sm:mr-auto'
+                  >
+                    {visibilityLoading ? (
+                      <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                    ) : (
+                      <Eye className='mr-2 h-4 w-4' />
+                    )}
+                    {t('review.unhide')}
+                  </Button>
+                )}
+                {isApproved && (
+                  <Button
+                    onClick={onHide}
+                    disabled={visibilityLoading}
+                    variant='outline'
+                    className='border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground sm:mr-auto'
+                  >
+                    {visibilityLoading ? (
+                      <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                    ) : (
+                      <EyeOff className='mr-2 h-4 w-4' />
+                    )}
+                    {t('review.hide')}
+                  </Button>
+                )}
+                {isPending && (
+                  <>
+                    <Button
+                      variant='outline'
+                      onClick={() => onRequestRevision(buildRejectionReason())}
+                      disabled={actionLoading}
+                      className='border-warning/40 text-warning-foreground hover:border-warning/60 hover:bg-warning/15 hover:text-warning-foreground'
+                    >
+                      {actionLoading ? (
+                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                      ) : (
+                        <RotateCcw className='mr-2 h-4 w-4' />
+                      )}
+                      {t('review.requestRevisionButton')}
+                    </Button>
+                    <Button
+                      variant='outline'
+                      onClick={() => onReject(buildRejectionReason())}
+                      disabled={actionLoading}
+                      className='border-destructive/30 text-destructive hover:border-destructive/50 hover:bg-destructive/10 hover:text-destructive'
+                    >
+                      {actionLoading ? (
+                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                      ) : (
+                        <XCircle className='mr-2 h-4 w-4' />
+                      )}
+                      {t('review.rejectButton')}
+                    </Button>
+                    <Button
+                      onClick={() => onApprove(verificationNotes)}
+                      disabled={actionLoading}
+                    >
+                      {actionLoading ? (
+                        <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+                      ) : (
+                        <CheckCircle className='mr-2 h-4 w-4' />
+                      )}
+                      {t('review.approveButton')}
+                    </Button>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1805,7 +1805,10 @@
       "rejectionReasonPlaceholder": "Enter reason for rejection...",
       "approveButton": "Approve Post",
       "rejectButton": "Reject Post",
-      "requestRevisionButton": "Request Revision"
+      "requestRevisionButton": "Request Revision",
+      "hide": "Hide temporarily",
+      "unhide": "Unhide",
+      "hideReason": "Temporarily hidden by admin"
     },
     "aiScheduler": {
       "title": "AI Auto-Moderation",
@@ -1943,7 +1946,11 @@
       "rejectError": "Failed to reject listing. Please try again.",
       "revisionDetailsRequired": "Please provide details on what needs to be revised.",
       "revisionSuccess": "Revision requested. Owner will be notified to update the listing.",
-      "revisionError": "Failed to request revision. Please try again."
+      "revisionError": "Failed to request revision. Please try again.",
+      "hideSuccess": "Listing has been temporarily hidden.",
+      "hideError": "Failed to hide the listing.",
+      "unhideSuccess": "Listing is visible again.",
+      "unhideError": "Failed to unhide the listing."
     }
   },
   "reports": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1769,7 +1769,10 @@
       "rejectionReasonPlaceholder": "Nhập lý do từ chối...",
       "approveButton": "Duyệt Bài Đăng",
       "rejectButton": "Từ Chối Bài Đăng",
-      "requestRevisionButton": "Yêu Cầu Sửa Đổi"
+      "requestRevisionButton": "Yêu Cầu Sửa Đổi",
+      "hide": "Ẩn tạm thời",
+      "unhide": "Hiện lại",
+      "hideReason": "Tạm ẩn bởi quản trị viên"
     },
     "aiScheduler": {
       "title": "Tự động kiểm duyệt AI",
@@ -1907,7 +1910,11 @@
       "rejectError": "Không thể từ chối tin đăng. Vui lòng thử lại.",
       "revisionDetailsRequired": "Vui lòng cung cấp chi tiết cần chỉnh sửa.",
       "revisionSuccess": "Đã yêu cầu chỉnh sửa. Chủ tin sẽ được thông báo để cập nhật.",
-      "revisionError": "Không thể yêu cầu chỉnh sửa. Vui lòng thử lại."
+      "revisionError": "Không thể yêu cầu chỉnh sửa. Vui lòng thử lại.",
+      "hideSuccess": "Đã ẩn tạm thời tin đăng.",
+      "hideError": "Ẩn tin đăng thất bại.",
+      "unhideSuccess": "Tin đăng đã hiển thị trở lại.",
+      "unhideError": "Hiện lại tin đăng thất bại."
     }
   },
   "reports": {


### PR DESCRIPTION
Admins had no way to hide or restore a listing from the posts moderation view - that action only existed inside the Reports flow. Port the same toggle (Eye/EyeOff, ListingService.hideListing / unhideListing) into PostReviewModal's action footer: Unhide shows for a currently-hidden listing, Hide shows for an approved one.