### PR TITLE
AI auto-verify: auto-run AI analysis on post review dialog open

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -105,8 +105,8 @@ export const PATHS = {
     CHECK_DUPLICATE: '/v1/ai/listings/:listingId/check-duplicate', // POST run AI duplicate check for an existing listing
     MODERATION_RESULT: '/v1/ai/listings/:listingId/moderation-result', // GET stored auto-moderation AI result
     SERVICE_STATUS: '/v1/ai/listings/service-status', // GET Python AI service reachability
-    SCHEDULER_STATUS: '/v1/ai/listings/scheduler/status', // GET auto-moderation cronjob enabled state (admin)
-    SCHEDULER_TOGGLE: '/v1/ai/listings/scheduler/toggle', // PUT enable/disable auto-moderation scheduler (admin)
+    AUTO_VERIFY_STATUS: '/v1/ai/listings/auto-verify/status', // GET whether the review dialog auto-runs AI on open (admin)
+    AUTO_VERIFY_TOGGLE: '/v1/ai/listings/auto-verify/toggle', // PUT enable/disable dialog auto-verify (admin)
   },
 
   // News endpoints

--- a/src/api/services/ai-verification.service.ts
+++ b/src/api/services/ai-verification.service.ts
@@ -6,7 +6,7 @@ import {
   AiDuplicateCheckResult,
   AiStoredModerationResult,
   AiServiceStatus,
-  AiSchedulerStatus,
+  AiAutoVerifySetting,
   ApiResponse,
 } from '@/api/types/ai-verification.type'
 
@@ -54,7 +54,10 @@ export class AiVerificationService {
   ): Promise<ApiResponse<AiDuplicateCheckResult>> {
     return apiRequest<AiDuplicateCheckResult>({
       method: 'POST',
-      url: PATHS.AI_VERIFICATION.CHECK_DUPLICATE.replace(':listingId', listingId),
+      url: PATHS.AI_VERIFICATION.CHECK_DUPLICATE.replace(
+        ':listingId',
+        listingId,
+      ),
       // Candidate retrieval + LLM + image hashing can take a while.
       timeout: 60000,
     })
@@ -94,33 +97,34 @@ export class AiVerificationService {
   }
 
   /**
-   * Read whether the background AI auto-moderation cronjob is enabled.
-   * GET /v1/ai/listings/scheduler/status
+   * Read whether the review dialog auto-runs AI analysis on open.
+   * GET /v1/ai/listings/auto-verify/status
    *
    * Admin only (Bearer token + X-Admin-Id added by the axios interceptor).
    */
-  static async getSchedulerStatus(): Promise<ApiResponse<AiSchedulerStatus>> {
-    return apiRequest<AiSchedulerStatus>({
+  static async getAutoVerifyStatus(): Promise<
+    ApiResponse<AiAutoVerifySetting>
+  > {
+    return apiRequest<AiAutoVerifySetting>({
       method: 'GET',
-      url: PATHS.AI_VERIFICATION.SCHEDULER_STATUS,
+      url: PATHS.AI_VERIFICATION.AUTO_VERIFY_STATUS,
     })
   }
 
   /**
-   * Enable or disable the AI auto-moderation scheduler at runtime.
-   * PUT /v1/ai/listings/scheduler/toggle?enabled={true|false}
+   * Enable or disable dialog auto-verify at runtime.
+   * PUT /v1/ai/listings/auto-verify/toggle?enabled={true|false}
    *
-   * Admin only. The toggle is an in-memory runtime flag on the backend and
-   * resets to enabled on server restart.
+   * Admin only. Persisted in the DB, survives server restarts.
    *
-   * @param enabled - true to resume batch processing, false to pause it
+   * @param enabled - true to auto-run AI analysis when the review dialog opens, false to require a manual click
    */
-  static async toggleScheduler(
+  static async toggleAutoVerify(
     enabled: boolean,
-  ): Promise<ApiResponse<AiSchedulerStatus>> {
-    return apiRequest<AiSchedulerStatus>({
+  ): Promise<ApiResponse<AiAutoVerifySetting>> {
+    return apiRequest<AiAutoVerifySetting>({
       method: 'PUT',
-      url: PATHS.AI_VERIFICATION.SCHEDULER_TOGGLE,
+      url: PATHS.AI_VERIFICATION.AUTO_VERIFY_TOGGLE,
       params: { enabled },
     })
   }

--- a/src/api/types/ai-verification.type.ts
+++ b/src/api/types/ai-verification.type.ts
@@ -188,19 +188,22 @@ export interface AiServiceStatus {
 }
 
 // ---------------------------------------------------------------------------
-// Admin scheduler control
-//   GET /v1/ai/listings/scheduler/status
-//   PUT /v1/ai/listings/scheduler/toggle?enabled={true|false}
+// Admin auto-verify control
+//   GET /v1/ai/listings/auto-verify/status
+//   PUT /v1/ai/listings/auto-verify/toggle?enabled={true|false}
 //
 // Requires an admin Bearer token + X-Admin-Id header (injected automatically by
 // the axios request interceptor). Roles allowed: SA, UA, SPA.
+//
+// When enabled, the post review dialog auto-runs AI analysis as soon as it
+// opens instead of requiring a manual "Verify" click. Persisted in the DB.
 //
 // NOTE: backend fields here are camelCase (Spring Boot DTO), unlike the
 // snake_case Python verification payload above.
 // ---------------------------------------------------------------------------
 
-export interface AiSchedulerStatus {
-  aiSchedulerEnabled: boolean
+export interface AiAutoVerifySetting {
+  aiAutoVerifyEnabled: boolean
   checkedAt?: string
   /** Present on toggle responses. */
   updatedAt?: string

--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -15,7 +15,7 @@ import {
 import { PostStats } from '@/components/molecules/posts/PostStats'
 import { PostTable } from '@/components/organisms/posts/PostTable'
 import { PostReviewModal } from '@/components/organisms/posts/PostReviewModal'
-import { AiSchedulerControl } from '@/components/molecules/aiServiceStatus/AiSchedulerControl'
+import { AiAutoVerifyControl } from '@/components/molecules/aiServiceStatus/AiAutoVerifyControl'
 
 // Backend success envelope code (see constants/env API_RESPONSE_CODES.SUCCESS).
 const SUCCESS_CODE = '999999'
@@ -273,7 +273,7 @@ const PostVerification = () => {
         </div>
       ) : (
         <div className='space-y-6'>
-          <AiSchedulerControl />
+          <AiAutoVerifyControl />
 
           <PostStats stats={stats} />
 

--- a/src/components/molecules/aiServiceStatus/AiAutoVerifyControl.tsx
+++ b/src/components/molecules/aiServiceStatus/AiAutoVerifyControl.tsx
@@ -9,7 +9,7 @@ import { AiVerificationService } from '@/api/services/ai-verification.service'
 import { useAuthStore } from '@/store/auth/index.store'
 
 /**
- * Admin roles allowed to read/toggle the auto-moderation scheduler.
+ * Admin roles allowed to read/toggle AI auto-verify.
  *
  * The JWT's `user.roles` carries human-readable role names (e.g. "Super Admin"),
  * not the short codes the admin-list API returns ("SA"). We accept both so the
@@ -24,21 +24,22 @@ const ALLOWED_ROLES = [
   'Support Admin',
 ]
 
-interface AiSchedulerControlProps {
+interface AiAutoVerifyControlProps {
   className?: string
 }
 
 /**
- * Admin control for the AI auto-moderation scheduler.
+ * Admin control for AI auto-verify.
  *
- * Reads the current enabled/paused state on mount and lets allowed admins
- * (SA / UA / SPA) flip the background cronjob ON or OFF at runtime. The
- * backend flag is in-memory and resets to enabled on server restart, which is
- * surfaced to the admin via the helper copy.
+ * Reads the current enabled/disabled state on mount and lets allowed admins
+ * (SA / UA / SPA) flip it ON or OFF. When ON, the post review dialog
+ * auto-runs AI analysis as soon as it opens instead of requiring a manual
+ * "Verify" click. The flag is persisted in the DB and survives server
+ * restarts.
  *
  * Renders nothing for admins whose roles are not permitted to manage it.
  */
-export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
+export const AiAutoVerifyControl: React.FC<AiAutoVerifyControlProps> = ({
   className,
 }) => {
   const t = useTranslations('posts')
@@ -52,9 +53,9 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
   const fetchStatus = useCallback(async () => {
     setLoading(true)
     try {
-      const res = await AiVerificationService.getSchedulerStatus()
+      const res = await AiVerificationService.getAutoVerifyStatus()
       if (res.success && res.data) {
-        setEnabled(res.data.aiSchedulerEnabled)
+        setEnabled(res.data.aiAutoVerifyEnabled)
       } else {
         setEnabled(null)
       }
@@ -76,19 +77,21 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
     // Optimistic update; revert on failure.
     setEnabled(next)
     try {
-      const res = await AiVerificationService.toggleScheduler(next)
+      const res = await AiVerificationService.toggleAutoVerify(next)
       if (res.success && res.data) {
-        setEnabled(res.data.aiSchedulerEnabled)
+        setEnabled(res.data.aiAutoVerifyEnabled)
         toast.success(
-          next ? t('aiScheduler.enabledToast') : t('aiScheduler.disabledToast'),
+          next
+            ? t('aiAutoVerify.enabledToast')
+            : t('aiAutoVerify.disabledToast'),
         )
       } else {
         setEnabled(!next)
-        toast.error(res.message || t('aiScheduler.toggleError'))
+        toast.error(res.message || t('aiAutoVerify.toggleError'))
       }
     } catch {
       setEnabled(!next)
-      toast.error(t('aiScheduler.toggleError'))
+      toast.error(t('aiAutoVerify.toggleError'))
     } finally {
       setToggling(false)
     }
@@ -118,7 +121,7 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
         </span>
         <div className='space-y-0.5'>
           <div className='flex items-center gap-2 text-sm font-semibold text-foreground'>
-            {t('aiScheduler.title')}
+            {t('aiAutoVerify.title')}
             {!loading && enabled !== null && (
               <span
                 className={cn(
@@ -134,15 +137,14 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
                     isOn ? 'bg-success' : 'bg-muted-foreground',
                   )}
                 />
-                {isOn ? t('aiScheduler.statusOn') : t('aiScheduler.statusOff')}
+                {isOn
+                  ? t('aiAutoVerify.statusOn')
+                  : t('aiAutoVerify.statusOff')}
               </span>
             )}
           </div>
           <p className='max-w-md text-xs text-muted-foreground'>
-            {t('aiScheduler.description')}
-          </p>
-          <p className='text-[11px] text-muted-foreground/70'>
-            {t('aiScheduler.restartNote')}
+            {t('aiAutoVerify.description')}
           </p>
         </div>
       </div>
@@ -150,7 +152,7 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
       {loading ? (
         <div className='flex items-center gap-2 text-xs text-muted-foreground'>
           <Loader2 className='h-4 w-4 animate-spin' />
-          {t('aiScheduler.loading')}
+          {t('aiAutoVerify.loading')}
         </div>
       ) : enabled === null ? (
         <button
@@ -158,14 +160,14 @@ export const AiSchedulerControl: React.FC<AiSchedulerControlProps> = ({
           onClick={fetchStatus}
           className='text-xs font-medium text-primary transition-colors hover:text-primary/80'
         >
-          {t('aiScheduler.retry')}
+          {t('aiAutoVerify.retry')}
         </button>
       ) : (
         <button
           type='button'
           role='switch'
           aria-checked={isOn}
-          aria-label={t('aiScheduler.title')}
+          aria-label={t('aiAutoVerify.title')}
           onClick={handleToggle}
           disabled={toggling}
           className={cn(

--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   Sparkles,
@@ -107,52 +107,15 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
   const [loading, setLoading] = useState(false)
   const [loadingStore, setLoadingStore] = useState(false)
   const [result, setResult] = useState<AiVerificationResult | null>(null)
-  const [duplicate, setDuplicate] = useState<AiDuplicateCheckResult | null>(null)
+  const [duplicate, setDuplicate] = useState<AiDuplicateCheckResult | null>(
+    null,
+  )
   const [loadedFromStore, setLoadedFromStore] = useState(false)
   const [analyzedAt, setAnalyzedAt] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [serviceAvailable, setServiceAvailable] = useState<boolean | null>(null)
 
-  // On open, reset and load any result the auto-moderation cronjob already
-  // stored — so reopening the modal shows the analysis instantly instead of
-  // re-running the AI (and re-spending Gemini tokens). Falls back to the manual
-  // "Run analysis" flow when nothing is stored yet.
-  useEffect(() => {
-    setResult(null)
-    setDuplicate(null)
-    setError(null)
-    setLoading(false)
-    setLoadedFromStore(false)
-    setAnalyzedAt(null)
-
-    if (!open || !post) return
-
-    let cancelled = false
-    setLoadingStore(true)
-    AiVerificationService.getStoredResult(post.id)
-      .then((res) => {
-        if (cancelled) return
-        const data = res.success ? res.data : null
-        if (data && (data.verification || data.duplicateCheck)) {
-          if (data.verification) setResult(data.verification)
-          if (data.duplicateCheck) setDuplicate(data.duplicateCheck)
-          setLoadedFromStore(true)
-          setAnalyzedAt(data.analyzedAt ?? null)
-        }
-      })
-      .catch(() => {
-        // No stored result — silent; admin can run analysis manually.
-      })
-      .finally(() => {
-        if (!cancelled) setLoadingStore(false)
-      })
-
-    return () => {
-      cancelled = true
-    }
-  }, [post, open])
-
-  const runAnalysis = async () => {
+  const runAnalysis = useCallback(async () => {
     if (!post) return
     setLoading(true)
     setError(null)
@@ -192,7 +155,55 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
     } finally {
       setLoading(false)
     }
-  }
+  }, [post, t])
+
+  // On open: reset, then show any already-stored AI result instantly (no
+  // re-run, no re-spent Gemini tokens). If nothing is stored yet, auto-run the
+  // analysis when the admin's auto-verify setting is on — so the dialog shows
+  // AI results on open without a manual "Verify" click. Falls back to the
+  // manual button when auto-verify is off or the status check fails.
+  useEffect(() => {
+    setResult(null)
+    setDuplicate(null)
+    setError(null)
+    setLoading(false)
+    setLoadedFromStore(false)
+    setAnalyzedAt(null)
+
+    if (!open || !post) return
+
+    let cancelled = false
+    setLoadingStore(true)
+    AiVerificationService.getStoredResult(post.id)
+      .then((res) => {
+        if (cancelled) return
+        const data = res.success ? res.data : null
+        if (data && (data.verification || data.duplicateCheck)) {
+          if (data.verification) setResult(data.verification)
+          if (data.duplicateCheck) setDuplicate(data.duplicateCheck)
+          setLoadedFromStore(true)
+          setAnalyzedAt(data.analyzedAt ?? null)
+          return
+        }
+        // Nothing stored — auto-run when auto-verify is enabled.
+        return AiVerificationService.getAutoVerifyStatus().then((statusRes) => {
+          if (cancelled) return
+          if (statusRes.success && statusRes.data?.aiAutoVerifyEnabled) {
+            runAnalysis()
+          }
+        })
+      })
+      .catch(() => {
+        // No stored result / status — silent; admin can run analysis manually.
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingStore(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [post, open, runAnalysis])
 
   const duplicateDecisionColor = (decision: AiDuplicateDecision) =>
     decision === 'DUPLICATE'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1810,17 +1810,16 @@
       "unhide": "Unhide",
       "hideReason": "Temporarily hidden by admin"
     },
-    "aiScheduler": {
-      "title": "AI Auto-Moderation",
-      "description": "When enabled, pending listings are automatically analyzed by AI every 5 minutes. When paused, listings wait for manual review.",
-      "restartNote": "Runtime setting — resets to enabled when the server restarts.",
-      "statusOn": "Active",
-      "statusOff": "Paused",
-      "loading": "Loading scheduler...",
+    "aiAutoVerify": {
+      "title": "Auto-run AI analysis on open",
+      "description": "When enabled, AI analysis runs automatically as soon as the post review dialog opens, no need to click Verify. When disabled, admins must click the button to run AI manually.",
+      "statusOn": "Enabled",
+      "statusOff": "Disabled",
+      "loading": "Loading setting...",
       "retry": "Retry",
-      "enabledToast": "AI auto-moderation enabled. Listings will be processed automatically.",
-      "disabledToast": "AI auto-moderation paused. Listings will require manual review.",
-      "toggleError": "Failed to update the scheduler. Please try again."
+      "enabledToast": "Auto-run AI analysis on dialog open is now enabled.",
+      "disabledToast": "Auto-run AI analysis is disabled. Admins must click Verify manually.",
+      "toggleError": "Failed to update the setting. Please try again."
     },
     "aiAnalysis": {
       "title": "AI Analysis",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1774,17 +1774,16 @@
       "unhide": "Hiện lại",
       "hideReason": "Tạm ẩn bởi quản trị viên"
     },
-    "aiScheduler": {
-      "title": "Tự động kiểm duyệt AI",
-      "description": "Khi bật, các tin đang chờ sẽ được AI phân tích tự động mỗi 5 phút. Khi tạm dừng, các tin sẽ chờ duyệt thủ công.",
-      "restartNote": "Cài đặt thời gian chạy — sẽ tự bật lại khi máy chủ khởi động lại.",
-      "statusOn": "Đang hoạt động",
-      "statusOff": "Tạm dừng",
-      "loading": "Đang tải bộ lập lịch...",
+    "aiAutoVerify": {
+      "title": "Tự động phân tích AI khi mở bài đăng",
+      "description": "Khi bật, AI sẽ tự động phân tích ngay khi mở dialog xem xét bài đăng, không cần bấm nút Xác minh. Khi tắt, quản trị viên phải bấm nút để chạy AI thủ công.",
+      "statusOn": "Đang bật",
+      "statusOff": "Đang tắt",
+      "loading": "Đang tải cài đặt...",
       "retry": "Thử lại",
-      "enabledToast": "Đã bật tự động kiểm duyệt AI. Các tin sẽ được xử lý tự động.",
-      "disabledToast": "Đã tạm dừng tự động kiểm duyệt AI. Các tin sẽ cần duyệt thủ công.",
-      "toggleError": "Cập nhật bộ lập lịch thất bại. Vui lòng thử lại."
+      "enabledToast": "Đã bật tự động phân tích AI khi mở bài đăng.",
+      "disabledToast": "Đã tắt tự động phân tích AI. Cần bấm nút Xác minh thủ công.",
+      "toggleError": "Cập nhật cài đặt thất bại. Vui lòng thử lại."
     },
     "aiAnalysis": {
       "title": "Phân tích AI",


### PR DESCRIPTION
## Summary
- Dialog review bài đăng tự động chạy AI analysis ngay khi mở (nếu flag auto-verify bật), thay vì phải bấm nút Verify thủ công. Nút Verify/Re-run vẫn giữ để chạy lại.
- Đổi `AiSchedulerControl` → `AiAutoVerifyControl`, repoint sang endpoint `/v1/ai/listings/auto-verify/{status,toggle}` (flag giờ lưu ở DB bên BE), cập nhật copy/i18n cho đúng nghĩa mới.
- BE đi kèm: smartrent-backend PR feat/ai-auto-verify-dialog.

## Test plan
- [x] `tsc --noEmit` + `eslint` pass
- [ ] Bật flag → mở dialog thấy AI tự chạy; tắt flag → phải bấm Verify
