### PR TITLE
AI auto-verify: show pre-computed result on dialog open (no waiting)

### DIFF
--- a/src/components/molecules/aiServiceStatus/AiAutoVerifyControl.tsx
+++ b/src/components/molecules/aiServiceStatus/AiAutoVerifyControl.tsx
@@ -32,10 +32,11 @@ interface AiAutoVerifyControlProps {
  * Admin control for AI auto-verify.
  *
  * Reads the current enabled/disabled state on mount and lets allowed admins
- * (SA / UA / SPA) flip it ON or OFF. When ON, the post review dialog
- * auto-runs AI analysis as soon as it opens instead of requiring a manual
- * "Verify" click. The flag is persisted in the DB and survives server
- * restarts.
+ * (SA / UA / SPA) flip it ON or OFF. When ON, a background job analyses pending
+ * listings ahead of time and stores the result, so the review dialog shows it
+ * the instant it opens rather than the admin clicking Verify and waiting. It
+ * never approves or rejects — the admin still decides. The flag is persisted in
+ * the DB and survives server restarts.
  *
  * Renders nothing for admins whose roles are not permitted to manage it.
  */

--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -157,11 +157,13 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
     }
   }, [post, t])
 
-  // On open: reset, then show any already-stored AI result instantly (no
-  // re-run, no re-spent Gemini tokens). If nothing is stored yet, auto-run the
-  // analysis when the admin's auto-verify setting is on — so the dialog shows
-  // AI results on open without a manual "Verify" click. Falls back to the
-  // manual button when auto-verify is off or the status check fails.
+  // On open: reset, then show the AI result the background job already computed
+  // and stored — instantly, with no live AI call to wait on. When auto-verify is
+  // enabled, that result is normally ready by the time an admin gets here. If
+  // nothing is stored yet (auto-verify off, or the job hasn't reached this
+  // listing), the panel stays empty and the admin runs it with the manual button
+  // — we deliberately never kick off a live run here, since that would make them
+  // sit through a ~30s analysis just for opening the dialog.
   useEffect(() => {
     setResult(null)
     setDuplicate(null)
@@ -183,18 +185,10 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
           if (data.duplicateCheck) setDuplicate(data.duplicateCheck)
           setLoadedFromStore(true)
           setAnalyzedAt(data.analyzedAt ?? null)
-          return
         }
-        // Nothing stored — auto-run when auto-verify is enabled.
-        return AiVerificationService.getAutoVerifyStatus().then((statusRes) => {
-          if (cancelled) return
-          if (statusRes.success && statusRes.data?.aiAutoVerifyEnabled) {
-            runAnalysis()
-          }
-        })
       })
       .catch(() => {
-        // No stored result / status — silent; admin can run analysis manually.
+        // Nothing stored — silent; the admin can run the analysis manually.
       })
       .finally(() => {
         if (!cancelled) setLoadingStore(false)
@@ -203,7 +197,7 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
     return () => {
       cancelled = true
     }
-  }, [post, open, runAnalysis])
+  }, [post, open])
 
   const duplicateDecisionColor = (decision: AiDuplicateDecision) =>
     decision === 'DUPLICATE'

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1811,14 +1811,14 @@
       "hideReason": "Temporarily hidden by admin"
     },
     "aiAutoVerify": {
-      "title": "Auto-run AI analysis on open",
-      "description": "When enabled, AI analysis runs automatically as soon as the post review dialog opens, no need to click Verify. When disabled, admins must click the button to run AI manually.",
+      "title": "Background AI analysis",
+      "description": "When enabled, pending listings are analysed by AI in the background and the result is stored — so the review dialog shows it instantly on open, with no waiting. It never approves or rejects; admins still decide. When disabled, admins click Verify to run the AI manually.",
       "statusOn": "Enabled",
       "statusOff": "Disabled",
       "loading": "Loading setting...",
       "retry": "Retry",
-      "enabledToast": "Auto-run AI analysis on dialog open is now enabled.",
-      "disabledToast": "Auto-run AI analysis is disabled. Admins must click Verify manually.",
+      "enabledToast": "Background AI analysis enabled. Results will be ready when the review dialog opens.",
+      "disabledToast": "Background AI analysis disabled. Admins must click Verify manually.",
       "toggleError": "Failed to update the setting. Please try again."
     },
     "aiAnalysis": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1775,14 +1775,14 @@
       "hideReason": "Tạm ẩn bởi quản trị viên"
     },
     "aiAutoVerify": {
-      "title": "Tự động phân tích AI khi mở bài đăng",
-      "description": "Khi bật, AI sẽ tự động phân tích ngay khi mở dialog xem xét bài đăng, không cần bấm nút Xác minh. Khi tắt, quản trị viên phải bấm nút để chạy AI thủ công.",
+      "title": "Tự động phân tích AI nền",
+      "description": "Khi bật, AI chạy ngầm phân tích sẵn các tin đang chờ và lưu kết quả — mở dialog xem xét là thấy kết quả ngay, không phải đợi. AI không tự duyệt/từ chối, quản trị viên vẫn quyết định. Khi tắt, phải bấm nút Xác minh để chạy AI thủ công.",
       "statusOn": "Đang bật",
       "statusOff": "Đang tắt",
       "loading": "Đang tải cài đặt...",
       "retry": "Thử lại",
-      "enabledToast": "Đã bật tự động phân tích AI khi mở bài đăng.",
-      "disabledToast": "Đã tắt tự động phân tích AI. Cần bấm nút Xác minh thủ công.",
+      "enabledToast": "Đã bật phân tích AI nền. Kết quả sẽ có sẵn khi mở dialog xem xét.",
+      "disabledToast": "Đã tắt phân tích AI nền. Cần bấm nút Xác minh thủ công.",
       "toggleError": "Cập nhật cài đặt thất bại. Vui lòng thử lại."
     },
     "aiAnalysis": {


### PR DESCRIPTION
## Thay đổi
- Dialog xem xét bài đăng **hiện ngay** kết quả AI mà job nền đã tính sẵn (không gọi AI live, không phải đợi ~30s). Nếu chưa có kết quả (flag tắt, hoặc job nền chưa chạy tới tin đó) → để trống, admin bấm nút **Verify** chạy thủ công như cũ.
- Đổi `AiSchedulerControl` → `AiAutoVerifyControl`, repoint sang endpoint `/v1/ai/listings/auto-verify/{status,toggle}` (flag giờ lưu ở DB bên BE — bắt buộc, vì BE đã đổi endpoint ở #422).
- Copy/i18n mô tả đúng: AI chạy **ngầm** tính sẵn, không tự duyệt/từ chối.

BE đi kèm: smartrent-backend PR `feat/ai-background-verify-store-only`.

## Test plan
- [x] `tsc --noEmit` + `eslint` pass
- [ ] Bật flag + job nền đã chạy → mở dialog thấy kết quả AI ngay lập tức
- [ ] Chưa có kết quả → panel trống, bấm Verify chạy được