### PR TITLE
fix: drop the degraded-signal UI, the AI service errors properly now

### DIFF
--- a/src/api/types/ai-verification.type.ts
+++ b/src/api/types/ai-verification.type.ts
@@ -131,16 +131,6 @@ export interface AiVerificationResult {
   model_used: string
   processing_time_seconds: number
   verification_timestamp: string
-  /**
-   * False when the LLM call failed and the scores above come from basic
-   * field-presence rules, not a real AI analysis. Absent (undefined) on older
-   * responses — treat only an explicit `false` as degraded.
-   */
-  ai_available?: boolean
-  /** Machine-readable reason the AI did not run, e.g. "LLM_QUOTA_EXCEEDED". */
-  error_code?: string | null
-  /** Underlying provider error, for admin diagnostics. */
-  error_detail?: string | null
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -283,26 +283,6 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
       {/* Result */}
       {result && !loading && (
         <div className='mt-4 space-y-4'>
-          {/* Degraded notice: the AI never ran, the numbers below are placeholders */}
-          {result.ai_available === false && (
-            <div className='flex items-start gap-2.5 rounded-lg border border-warning/30 bg-warning/10 dark:bg-warning/20 p-3'>
-              <AlertTriangle className='mt-0.5 h-4 w-4 flex-shrink-0 text-warning-foreground' />
-              <div className='min-w-0 space-y-0.5'>
-                <div className='text-sm font-medium text-foreground'>
-                  {t('aiAnalysis.degraded.title')}
-                </div>
-                <p className='text-xs text-muted-foreground'>
-                  {t('aiAnalysis.degraded.description')}
-                </p>
-                {result.error_code && (
-                  <p className='pt-0.5 font-mono text-[11px] text-muted-foreground/70'>
-                    {result.error_code}
-                  </p>
-                )}
-              </div>
-            </div>
-          )}
-
           {/* Score + suggestion summary — three cards on one baseline grid.
               Each card is a flex column with a pinned footer (mt-auto) so the
               rows line up no matter which card is tallest. @lg (>=512px of
@@ -312,20 +292,13 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
             <div
               className={cn(
                 'flex flex-col rounded-lg border p-3',
-                result.ai_available === false
-                  ? 'border-border/70 bg-muted/40'
-                  : getScoreColorClasses(result.score),
+                getScoreColorClasses(result.score),
               )}
             >
               <div className='text-xs font-medium opacity-80'>
                 {t('aiAnalysis.score')}
               </div>
-              <div
-                className={cn(
-                  'mt-1 text-2xl font-bold tabular-nums leading-none',
-                  result.ai_available === false && 'text-muted-foreground',
-                )}
-              >
+              <div className='mt-1 text-2xl font-bold tabular-nums leading-none'>
                 {toPercent(result.score)}%
               </div>
               <div className='mt-auto pt-2'>
@@ -333,9 +306,7 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                   <div
                     className={cn(
                       'h-1.5 rounded-full',
-                      result.ai_available === false
-                        ? 'bg-muted-foreground/40'
-                        : getScoreBarColor(result.score),
+                      getScoreBarColor(result.score),
                     )}
                     style={{ width: `${toPercent(result.score)}%` }}
                   />

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1830,10 +1830,6 @@
       "loadingStored": "Loading saved result…",
       "storedResult": "Auto-moderation result",
       "storedNotice": "Auto-moderation result at {time}",
-      "degraded": {
-        "title": "AI could not analyse — these are not AI scores",
-        "description": "The scores below come from basic checks (required fields, image count…), not an AI assessment. Please review this listing manually."
-      },
       "error": "AI verification failed. Please try again.",
       "serviceOnline": "AI service online",
       "serviceOffline": "AI service offline",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1794,10 +1794,6 @@
       "loadingStored": "Đang tải kết quả đã lưu…",
       "storedResult": "Kết quả kiểm duyệt tự động",
       "storedNotice": "Kết quả kiểm duyệt tự động lúc {time}",
-      "degraded": {
-        "title": "AI không phân tích được — đây không phải kết quả của AI",
-        "description": "Điểm số bên dưới chỉ dựa trên quy tắc kiểm tra cơ bản (đủ trường, đủ ảnh…), không phải AI đánh giá. Vui lòng tự xem xét thủ công."
-      },
       "error": "Xác minh AI thất bại. Vui lòng thử lại.",
       "serviceOnline": "Dịch vụ AI đang hoạt động",
       "serviceOffline": "Dịch vụ AI ngừng hoạt động",


### PR DESCRIPTION
The AI service no longer returns 200 with fabricated basic-rule scores when the LLM fails (see companion smartrent-ai / smartrent-backend PRs) — it now returns a real HTTP error, which the existing "AI verification failed. Please try again." banner already surfaces correctly (apiRequest never throws, it resolves success:false on a non-2xx, exactly what runAnalysis already branches on).

That makes ai_available/error_code on AiVerificationResult and the warning banner built around them dead: `result` now only ever holds a real analysis. Removed both, plus the now-unused degraded.* i18n keys.