### PR TITLE
fix: stop DataTable frontend filters from dropping every row

### DIFF
--- a/src/components/organisms/DataTable/context.tsx
+++ b/src/components/organisms/DataTable/context.tsx
@@ -11,9 +11,48 @@ import type {
   SortConfig,
   PaginationConfig,
   FilterMode,
+  FilterConfig,
 } from './types'
 
 const DataTableContext = createContext<DataTableContextValue | null>(null)
+
+// Pagination state is kept in the same record as the filter values so API mode
+// can forward it in one payload. Frontend filtering must skip these keys — they
+// are not row fields, and matching them against `item[key]` drops every row.
+const PAGINATION_KEYS = new Set(['page', 'pageSize'])
+
+// Match one row against one active filter value. The filter's declared type
+// decides the strategy: only free-text search is a substring match, everything
+// else compares whole values — a `select` for status 'PENDING' must not match a
+// row whose status merely contains that text.
+function matchesFilter(
+  itemValue: unknown,
+  value: unknown,
+  filter?: FilterConfig,
+): boolean {
+  if (Array.isArray(value)) {
+    return value.some((v) => String(itemValue) === String(v))
+  }
+
+  // CSV values (e.g. role:SA,UA) stand for "any of these".
+  if (filter?.allowMultiple && typeof value === 'string') {
+    return value
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean)
+      .some((v) => String(itemValue) === v)
+  }
+
+  if (filter?.type === 'search' && typeof value === 'string') {
+    return String(itemValue).toLowerCase().includes(value.toLowerCase())
+  }
+
+  if (typeof value === 'string') {
+    return String(itemValue).toLowerCase() === value.toLowerCase()
+  }
+
+  return itemValue === value
+}
 
 export const useDataTable = <T = any,>() => {
   const context = useContext(
@@ -28,6 +67,8 @@ export const useDataTable = <T = any,>() => {
 interface DataTableProviderProps<T> {
   children: React.ReactNode
   data: T[]
+  /** Filter definitions, used by frontend mode to pick a match strategy per field. */
+  filterConfig?: FilterConfig[]
   filterMode?: FilterMode
   filterValues?: Record<string, any> // External filter values for controlled mode
   onFilterChange?: (filters: Record<string, any>) => void
@@ -42,6 +83,7 @@ interface DataTableProviderProps<T> {
 export function DataTableProvider<T = any>({
   children,
   data,
+  filterConfig,
   filterMode = 'frontend',
   filterValues: externalFilterValues,
   onFilterChange,
@@ -73,28 +115,19 @@ export function DataTableProvider<T = any>({
 
     // Apply filters
     Object.entries(filters).forEach(([key, value]) => {
+      if (PAGINATION_KEYS.has(key)) return
       if (!value || value === '' || value === 'all') return
+      if (Array.isArray(value) && value.length === 0) return
 
-      result = result.filter((item: any) => {
-        const itemValue = item[key]
+      const filter = filterConfig?.find((f) => f.id === key)
 
-        if (typeof value === 'string') {
-          // Search filter - case insensitive
-          return String(itemValue).toLowerCase().includes(value.toLowerCase())
-        }
-
-        if (Array.isArray(value)) {
-          // Multi-select filter
-          return value.includes(itemValue)
-        }
-
-        // Exact match filter
-        return itemValue === value
-      })
+      result = result.filter((item: any) =>
+        matchesFilter(item[key], value, filter),
+      )
     })
 
     return result
-  }, [data, filters, filterMode])
+  }, [data, filters, filterMode, filterConfig])
 
   // Sort data (frontend mode only)
   const sortedData = useMemo(() => {

--- a/src/components/organisms/DataTable/index.tsx
+++ b/src/components/organisms/DataTable/index.tsx
@@ -184,6 +184,7 @@ function DataTableContent<T = any>({
 export function DataTable<T = any>(props: DataTableProps<T>) {
   const {
     data,
+    filters,
     filterMode = 'frontend',
     filterValues,
     onFilterChange,
@@ -199,6 +200,7 @@ export function DataTable<T = any>(props: DataTableProps<T>) {
   return (
     <DataTableProvider
       data={data}
+      filterConfig={filters}
       filterMode={filterMode}
       filterValues={filterValues}
       onFilterChange={onFilterChange}
@@ -209,7 +211,11 @@ export function DataTable<T = any>(props: DataTableProps<T>) {
       totalItems={totalItems}
       loading={loading}
     >
-      <DataTableContent<T> {...contentProps} filterMode={filterMode} />
+      <DataTableContent<T>
+        {...contentProps}
+        filters={filters}
+        filterMode={filterMode}
+      />
     </DataTableProvider>
   )
 }


### PR DESCRIPTION
Picking a status in the moderation reports filter emptied the table.

Pagination state lives in the same record as the filter values so API mode can forward it as one payload, but the frontend filter loop walked that whole record and treated each key as a row field. setFilter injects page: 1, so every filter change compared item.page === 1 and matched nothing. clearFilters set { page: 1, pageSize } and emptied it the same way.

Skip the pagination keys when filtering client-side, and give the provider the filter definitions so each field picks a match strategy: only free-text search stays a substring match, select/multi-select now compare whole values. Previously a select for ACTIVE also matched INACTIVE.

Reports is the only table filtering client-side today; the rest use filterMode='api' and return before this code.