### PR TITLE
fix: drop media index prefix from AI issue list on posts review

### DIFF
--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -29,6 +29,7 @@ import {
   getSuggestedStatusColor,
   getSeverityColor,
   toPercent,
+  formatAiIssues,
 } from '@/utils/ai-verification.utils'
 import { AiServiceStatusBadge } from '@/components/molecules/aiServiceStatus/AiServiceStatusBadge'
 
@@ -58,50 +59,54 @@ const ValidationCard: React.FC<{
   stats,
   issues,
   issuesLabel,
-}) => (
-  <div className='rounded-lg border border-border/70 p-3'>
-    <div className='flex items-start justify-between gap-2'>
-      <span className='min-w-0 flex-1 break-words text-sm font-medium text-foreground'>
-        {title}
-      </span>
-      <Badge
-        variant='outline'
-        className={cn(
-          'shrink-0 text-xs',
-          valid
-            ? 'bg-success/10 text-success-foreground dark:bg-success/20 border-success/30'
-            : 'bg-destructive/10 text-destructive dark:bg-destructive/20 border-destructive/30',
-        )}
-      >
-        {valid ? validLabel : invalidLabel}
-      </Badge>
-    </div>
-    <div className='mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground'>
-      <span>
-        {scoreLabel}: <span className='font-semibold'>{scorePct}%</span>
-      </span>
-      {stats?.map((s) => (
-        <span key={s.label}>
-          {s.label}: <span className='font-semibold'>{s.value}</span>
+}) => {
+  const displayIssues = formatAiIssues(issues)
+
+  return (
+    <div className='rounded-lg border border-border/70 p-3'>
+      <div className='flex items-start justify-between gap-2'>
+        <span className='min-w-0 flex-1 break-words text-sm font-medium text-foreground'>
+          {title}
         </span>
-      ))}
-    </div>
-    {issues.length > 0 && (
-      <div className='mt-2'>
-        <div className='text-xs font-medium text-foreground/80'>
-          {issuesLabel}
-        </div>
-        <ul className='mt-1 list-inside list-disc space-y-0.5 text-xs text-muted-foreground'>
-          {issues.map((issue, i) => (
-            <li key={i} className='break-words'>
-              {issue}
-            </li>
-          ))}
-        </ul>
+        <Badge
+          variant='outline'
+          className={cn(
+            'shrink-0 text-xs',
+            valid
+              ? 'bg-success/10 text-success-foreground dark:bg-success/20 border-success/30'
+              : 'bg-destructive/10 text-destructive dark:bg-destructive/20 border-destructive/30',
+          )}
+        >
+          {valid ? validLabel : invalidLabel}
+        </Badge>
       </div>
-    )}
-  </div>
-)
+      <div className='mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground'>
+        <span>
+          {scoreLabel}: <span className='font-semibold'>{scorePct}%</span>
+        </span>
+        {stats?.map((s) => (
+          <span key={s.label}>
+            {s.label}: <span className='font-semibold'>{s.value}</span>
+          </span>
+        ))}
+      </div>
+      {displayIssues.length > 0 && (
+        <div className='mt-2'>
+          <div className='text-xs font-medium text-foreground/80'>
+            {issuesLabel}
+          </div>
+          <ul className='mt-1 list-inside list-disc space-y-0.5 text-xs text-muted-foreground'>
+            {displayIssues.map((issue) => (
+              <li key={issue} className='break-words'>
+                {issue}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}
 
 export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
   post,

--- a/src/utils/ai-verification.utils.ts
+++ b/src/utils/ai-verification.utils.ts
@@ -114,3 +114,31 @@ export const getSeverityColor = (level: AiSeverity | AiPriority): string => {
 /** Round a 0..1 score to a whole percentage for display. */
 export const toPercent = (value: number): number =>
   Math.round((Number.isFinite(value) ? value : 0) * 100)
+
+// The AI prefixes each media issue with the index of the offending item
+// ("Ảnh 1: ...", "Video 2: ..."). The indices do not map to anything the
+// moderator can act on in the modal, so they are stripped for display.
+const MEDIA_INDEX_PREFIX =
+  /^\s*(?:ảnh|hình|image|photo|video)\s*(?:số\s*)?\d+\s*[:\-–]\s*/i
+
+/**
+ * Strip the leading media index from AI issue strings and drop the duplicates
+ * that stripping exposes (e.g. three separate "anime character" issues for
+ * three bad photos collapse into one line).
+ */
+export const formatAiIssues = (issues: string[]): string[] => {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const issue of issues) {
+    const stripped = issue.replace(MEDIA_INDEX_PREFIX, '').trim()
+    if (!stripped) continue
+
+    const key = stripped.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(stripped.charAt(0).toUpperCase() + stripped.slice(1))
+  }
+
+  return result
+}


### PR DESCRIPTION
The AI prefixes each media issue with the index of the offending item ("Ảnh 1: ...", "Video 2: ..."), which the moderator cannot act on in the modal — the panel has no image numbering to match it against. Strip the prefix for display and collapse the duplicates it was hiding, so four issues across four bad photos read as the two distinct problems they are.