### PR TITLE
feat(posts): rework AI analysis panel + trim notification dropdown

### DIFF
--- a/src/api/paths.ts
+++ b/src/api/paths.ts
@@ -102,6 +102,7 @@ export const PATHS = {
   // AI listing verification endpoints (Spring Boot -> Python AI service)
   AI_VERIFICATION: {
     VERIFY: '/v1/ai/listings/verify', // POST run AI moderation on a listing payload
+    VERIFY_BY_ID: '/v1/ai/listings/:listingId/verify', // POST re-run AI moderation for an existing listing by ID and persist the result
     CHECK_DUPLICATE: '/v1/ai/listings/:listingId/check-duplicate', // POST run AI duplicate check for an existing listing
     MODERATION_RESULT: '/v1/ai/listings/:listingId/moderation-result', // GET stored auto-moderation AI result
     SERVICE_STATUS: '/v1/ai/listings/service-status', // GET Python AI service reachability

--- a/src/api/services/ai-verification.service.ts
+++ b/src/api/services/ai-verification.service.ts
@@ -41,6 +41,30 @@ export class AiVerificationService {
   }
 
   /**
+   * Re-run AI moderation (verify + duplicate check) for an existing listing by ID
+   * and PERSIST the fresh result as the latest stored moderation.
+   * POST /v1/ai/listings/:listingId/verify
+   *
+   * Unlike {@link verifyListing} (stateless), this writes to
+   * listing_ai_moderation, so the next {@link getStoredResult} — i.e. what the
+   * review dialog loads when the post is reopened — reflects this run. Returns
+   * the same shape as {@link getStoredResult} (verification + duplicateCheck +
+   * analyzedAt). Used by the manual "AI verify / re-verify" button.
+   *
+   * @param listingId - ID of the listing to re-verify
+   */
+  static async reVerifyById(
+    listingId: string,
+  ): Promise<ApiResponse<AiStoredModerationResult>> {
+    return apiRequest<AiStoredModerationResult>({
+      method: 'POST',
+      url: PATHS.AI_VERIFICATION.VERIFY_BY_ID.replace(':listingId', listingId),
+      // AI multimodal analysis can take ~20-30s; override the default timeout.
+      timeout: 60000,
+    })
+  }
+
+  /**
    * Run the AI duplicate-detection pipeline for an existing listing by ID.
    * POST /v1/ai/listings/:listingId/check-duplicate
    *

--- a/src/components/organisms/NotificationDropdown.tsx
+++ b/src/components/organisms/NotificationDropdown.tsx
@@ -79,20 +79,6 @@ export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({
           </div>
         )}
       </div>
-
-      {/* Footer - optional, can add "View all" link */}
-      {hasNotifications && (
-        <div className='p-3 border-t border-border/70 bg-muted/50'>
-          <Button
-            variant='ghost'
-            size='sm'
-            className='w-full text-sm text-muted-foreground hover:text-foreground'
-            onClick={onClose}
-          >
-            {t('viewAll', { defaultValue: 'View all notifications' })}
-          </Button>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
 import {
   Sparkles,
@@ -8,10 +8,12 @@ import {
   AlertTriangle,
   Lightbulb,
   CheckCircle2,
+  XCircle,
   Info,
   Files,
   History,
 } from 'lucide-react'
+import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
 import { cn } from '@/lib/utils'
 import { UIPostData } from '@/types/posts.type'
@@ -109,23 +111,52 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
 }) => {
   const t = useTranslations('posts')
   const [loadingStore, setLoadingStore] = useState(false)
+  const [loading, setLoading] = useState(false)
   const [result, setResult] = useState<AiVerificationResult | null>(null)
   const [duplicate, setDuplicate] = useState<AiDuplicateCheckResult | null>(
     null,
   )
   const [loadedFromStore, setLoadedFromStore] = useState(false)
   const [analyzedAt, setAnalyzedAt] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [serviceAvailable, setServiceAvailable] = useState<boolean | null>(null)
 
-  // On open: show the AI result the background auto-verify job already computed
-  // and stored — instantly, with no live AI call to wait on. There is no manual
-  // trigger: the panel purely reflects the auto-verify pipeline's output, so if
-  // nothing is stored yet (auto-verify off, or the job hasn't reached this
-  // listing), the panel just stays empty below the header.
+  // Manually (re-)run AI moderation for this listing. Unlike the stateless
+  // /verify, this by-id endpoint PERSISTS the fresh result, so reopening the
+  // post loads this very run via getStoredResult — the latest verification wins.
+  const runAnalysis = useCallback(async () => {
+    if (!post) return
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await AiVerificationService.reVerifyById(post.id)
+      if (res.success && res.data) {
+        setResult(res.data.verification ?? null)
+        setDuplicate(res.data.duplicateCheck ?? null)
+        setLoadedFromStore(true)
+        setAnalyzedAt(res.data.analyzedAt ?? null)
+        if (!res.data.verification) setError(t('aiAnalysis.error'))
+      } else {
+        setError(t('aiAnalysis.error'))
+      }
+    } catch {
+      setError(t('aiAnalysis.error'))
+    } finally {
+      setLoading(false)
+    }
+  }, [post, t])
+
+  // On open: show the AI result the background auto-verify job (or a previous
+  // manual re-verify) already computed and stored — instantly, with no live AI
+  // call to wait on. The admin can also re-run it on demand via the button
+  // below; that run is persisted so the latest result is what loads next time.
   useEffect(() => {
     setResult(null)
     setDuplicate(null)
     setLoadedFromStore(false)
     setAnalyzedAt(null)
+    setError(null)
+    setLoading(false)
 
     if (!open || !post) return
 
@@ -168,6 +199,14 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
     return t.has(key) ? t(key) : String(level)
   }
 
+  // Never surface the raw code (e.g. "PRICE_ANOMALY") to admins. Map every known
+  // code to a human label; the AI can emit codes beyond the typed union, so any
+  // unrecognized code falls back to a generic label instead of the raw string.
+  const violationLabel = (code: string) => {
+    const key = `aiAnalysis.violationCodeLabels.${code}`
+    return t.has(key) ? t(key) : t('aiAnalysis.violationCodeLabels.other')
+  }
+
   return (
     // @container: this panel is rendered at very different widths depending on
     // context — a fixed ~440px sidebar on desktop review, but the full modal
@@ -190,11 +229,11 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
             </div>
           </div>
         </div>
-        <AiServiceStatusBadge />
+        <AiServiceStatusBadge onStatusChange={setServiceAvailable} />
       </div>
 
       {/* Loaded from the auto-moderation cronjob's stored result */}
-      {loadedFromStore && (
+      {loadedFromStore && !loading && (
         <div className='mt-3 flex items-center gap-1.5 text-xs text-muted-foreground'>
           <History className='h-3.5 w-3.5' />
           {analyzedAt
@@ -206,15 +245,31 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
       )}
 
       {/* Fetching the stored result */}
-      {loadingStore && !result && (
+      {loadingStore && !loading && !result && (
         <div className='mt-3 flex items-center gap-2 text-sm text-muted-foreground'>
           <Loader2 className='h-4 w-4 animate-spin' />
           {t('aiAnalysis.loadingStored')}
         </div>
       )}
 
-      {/* Nothing stored yet — no manual trigger; nudge toward enabling auto-verify */}
-      {!loadingStore && !result && (
+      {/* Running a manual (re-)verification */}
+      {loading && (
+        <div className='mt-4 flex items-center gap-2 text-sm text-muted-foreground'>
+          <Loader2 className='h-4 w-4 animate-spin' />
+          {t('aiAnalysis.analyzing')}
+        </div>
+      )}
+
+      {/* Error from a manual run */}
+      {error && !loading && (
+        <div className='mt-4 flex items-start gap-2 rounded-lg border border-destructive/30 bg-destructive/10 dark:bg-destructive/20 p-3 text-sm text-destructive'>
+          <XCircle className='mt-0.5 h-4 w-4 shrink-0' />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {/* Nothing stored yet — nudge toward auto-verify or the manual button below */}
+      {!loadingStore && !loading && !error && !result && (
         <div className='mt-3 flex items-start gap-2 rounded-lg border border-dashed border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground'>
           <Info className='mt-0.5 h-3.5 w-3.5 shrink-0' />
           <span>{t('aiAnalysis.noResult')}</span>
@@ -222,14 +277,14 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
       )}
 
       {/* Result */}
-      {result && (
+      {result && !loading && (
         <div className='mt-4 space-y-4'>
-          {/* Score + suggestion summary — three cards on one baseline grid.
+          {/* Score + suggestion summary — two cards on one baseline grid.
               Each card is a flex column with a pinned footer (mt-auto) so the
-              rows line up no matter which card is tallest. @lg (>=512px of
-              panel width, not viewport) is the point at which 3 columns have
+              rows line up no matter which card is taller. @lg (>=512px of
+              panel width, not viewport) is the point at which 2 columns have
               room to breathe; below that they stack full-width. */}
-          <div className='grid grid-cols-1 gap-3 @lg:grid-cols-3'>
+          <div className='grid grid-cols-1 gap-3 @lg:grid-cols-2'>
             <div
               className={cn(
                 'flex flex-col rounded-lg border p-3',
@@ -269,20 +324,6 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                 >
                   {t(`aiAnalysis.suggested.${result.suggested_status}`)}
                 </Badge>
-              </div>
-            </div>
-
-            <div className='flex flex-col rounded-lg border border-border/70 bg-card p-3'>
-              <div className='text-xs font-medium text-muted-foreground'>
-                {t('aiAnalysis.confidence')}
-              </div>
-              <div className='mt-1 text-2xl font-bold tabular-nums leading-none text-foreground'>
-                {toPercent(result.confidence)}%
-              </div>
-              <div className='mt-auto truncate pt-2 text-[11px] text-muted-foreground/80'>
-                {result.model_used} ·{' '}
-                {result.processing_time_seconds.toFixed(1)}
-                {t('aiAnalysis.seconds')}
               </div>
             </div>
           </div>
@@ -331,7 +372,10 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
             </div>
           </div>
 
-          {/* Violation codes */}
+          {/* Violation codes — mapped to human labels (never the raw code). The
+              labels are full phrases, so these are wrapping chips rather than
+              nowrap pills: they wrap onto new lines when there are many, and long
+              text wraps inside a chip instead of overflowing the narrow panel. */}
           {result.violation_codes.length > 0 && (
             <div>
               <div className='mb-1.5 text-xs font-medium text-foreground/80'>
@@ -339,13 +383,15 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
               </div>
               <div className='flex flex-wrap gap-1.5'>
                 {result.violation_codes.map((code) => (
-                  <Badge
+                  <span
                     key={code}
-                    variant='outline'
-                    className='bg-destructive/10 text-destructive dark:bg-destructive/20 border-destructive/30 text-xs'
+                    className='inline-flex max-w-full items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 dark:bg-destructive/20 px-2 py-1 text-xs text-destructive'
                   >
-                    {code}
-                  </Badge>
+                    <AlertTriangle className='mt-px h-3 w-3 shrink-0' />
+                    <span className='min-w-0 break-words'>
+                      {violationLabel(code)}
+                    </span>
+                  </span>
                 ))}
               </div>
             </div>
@@ -595,13 +641,34 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
         </div>
       )}
 
-      {/* Footer: advisory note, only relevant once a result is showing */}
-      {result && (
-        <div className='mt-4 flex items-center gap-1.5 border-t border-primary/20 pt-3 text-xs text-muted-foreground/80'>
-          <CheckCircle2 className='h-3.5 w-3.5' />
-          {t('aiAnalysis.advisoryNote')}
+      {/* Footer: advisory note (when a result is showing) + manual (re-)verify.
+          The button always shows so admins can re-run AI on manually-verified
+          posts or ones that need another pass — the run is persisted, so the
+          latest result is what loads when the post is reopened. */}
+      <div className='mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-primary/20 pt-3'>
+        <div className='flex items-center gap-1.5 text-xs text-muted-foreground/80'>
+          {result && !loading && (
+            <>
+              <CheckCircle2 className='h-3.5 w-3.5' />
+              {t('aiAnalysis.advisoryNote')}
+            </>
+          )}
         </div>
-      )}
+        <Button
+          type='button'
+          size='sm'
+          onClick={runAnalysis}
+          disabled={loading || serviceAvailable === false}
+          className='text-sm'
+        >
+          {loading ? (
+            <Loader2 className='mr-2 h-4 w-4 animate-spin' />
+          ) : (
+            <Sparkles className='mr-2 h-4 w-4' />
+          )}
+          {result ? t('aiAnalysis.rerunButton') : t('aiAnalysis.runButton')}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1824,6 +1824,10 @@
     "aiAnalysis": {
       "title": "AI Analysis",
       "disclaimer": "AI-assisted moderation. The AI does not make the final decision.",
+      "runButton": "Verify with AI",
+      "rerunButton": "Re-analyze",
+      "analyzing": "Analyzing the listing with AI — this can take up to 30 seconds...",
+      "error": "AI verification failed. Please try again.",
       "loadingStored": "Loading saved result…",
       "storedResult": "Auto-moderation result",
       "storedNotice": "Auto-moderation result at {time}",
@@ -1893,6 +1897,17 @@
         "medium": "Medium",
         "high": "High",
         "critical": "Critical"
+      },
+      "violationCodeLabels": {
+        "SCAM": "Signs of fraud",
+        "INCONSISTENT_INFO": "Information doesn't match the images",
+        "STOCK_PHOTO": "Stock image, not an actual photo",
+        "CONTACT_IN_LISTING": "Contact info embedded in the listing",
+        "BLURRY_IMAGE": "Blurry, low-quality images",
+        "MISSING_MEDIA": "Missing images or videos",
+        "PRICE_ANOMALY": "Abnormal price",
+        "INAPPROPRIATE_CONTENT": "Inappropriate content",
+        "other": "Other violation"
       }
     },
     "listingTypes": {
@@ -2436,7 +2451,6 @@
     "title": "Notifications",
     "markAllRead": "Mark all as read",
     "empty": "No notifications yet",
-    "viewAll": "View all notifications",
     "types": {
       "NEW_REPORT": "New Report",
       "LISTING_RESUBMITTED": "Listing Resubmitted",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1788,6 +1788,10 @@
     "aiAnalysis": {
       "title": "Phân tích AI",
       "disclaimer": "Hỗ trợ kiểm duyệt bằng AI. AI không đưa ra quyết định cuối cùng.",
+      "runButton": "Xác minh bằng AI",
+      "rerunButton": "Phân tích lại",
+      "analyzing": "Đang phân tích nội dung bằng AI — có thể mất đến 30 giây...",
+      "error": "Xác minh AI thất bại. Vui lòng thử lại.",
       "loadingStored": "Đang tải kết quả đã lưu…",
       "storedResult": "Kết quả kiểm duyệt tự động",
       "storedNotice": "Kết quả kiểm duyệt tự động lúc {time}",
@@ -1857,6 +1861,17 @@
         "medium": "Trung bình",
         "high": "Cao",
         "critical": "Nghiêm trọng"
+      },
+      "violationCodeLabels": {
+        "SCAM": "Dấu hiệu lừa đảo",
+        "INCONSISTENT_INFO": "Thông tin không khớp với hình ảnh",
+        "STOCK_PHOTO": "Ảnh mạng, không phải ảnh thực tế",
+        "CONTACT_IN_LISTING": "Chèn thông tin liên hệ trong tin",
+        "BLURRY_IMAGE": "Ảnh mờ, kém chất lượng",
+        "MISSING_MEDIA": "Thiếu hình ảnh hoặc video",
+        "PRICE_ANOMALY": "Giá bất thường",
+        "INAPPROPRIATE_CONTENT": "Nội dung không phù hợp",
+        "other": "Vi phạm khác"
       }
     },
     "listingTypes": {
@@ -2400,7 +2415,6 @@
     "title": "Thông báo",
     "markAllRead": "Đánh dấu tất cả đã đọc",
     "empty": "Chưa có thông báo",
-    "viewAll": "Xem tất cả thông báo",
     "types": {
       "NEW_REPORT": "Báo cáo mới",
       "LISTING_RESUBMITTED": "Tin đăng gửi lại",


### PR DESCRIPTION
- Remove the "Độ tin cậy" (confidence) card from the post review dialog's AI analysis panel; the summary now shows Score + AI suggestion only.
- Map every AI violation code to a human-readable Vietnamese label (with an "other" fallback for codes beyond the known set) so the raw code string (e.g. PRICE_ANOMALY) is never shown to admins. Render them as wrapping chips that handle long labels and many items without overflowing the panel.
- Re-add the manual "Xác minh bằng AI / Phân tích lại" button. It calls the new POST /v1/ai/listings/{id}/verify endpoint, which persists the result, so reopening the post loads this latest run via getStoredResult.
- Remove the "Xem tất cả thông báo" (view all) button from the notification dropdown and its now-unused i18n keys.