### PR TITLE
feat(reports): show the resolution action taken on a report

### DIFF
--- a/src/api/types/listing-report.type.ts
+++ b/src/api/types/listing-report.type.ts
@@ -1,4 +1,13 @@
 // Types for listing report API
+
+// Concrete action an admin took when resolving a report. Mirrors the backend
+// ReportResolutionAction enum. Null for pending reports and legacy rows.
+export type ReportResolutionAction =
+  | 'SUSPENDED'
+  | 'REVISION_REQUESTED'
+  | 'DISMISSED'
+  | 'RESOLVED'
+
 export interface ListingReportReason {
   reasonId: number
   reasonText: string
@@ -20,6 +29,7 @@ export interface ListingReport {
   resolvedByName: string | null
   resolvedAt: string | null
   adminNotes: string | null
+  resolutionAction?: ReportResolutionAction | null
   createdAt: string
   updatedAt: string
 }
@@ -35,6 +45,9 @@ export interface ListingReportListResponse {
 export interface ResolveReportRequest {
   status: 'RESOLVED' | 'REJECTED'
   adminNotes?: string
+  // Concrete action taken, persisted for later display. If omitted the backend
+  // derives it from status/removeListing/ownerActionRequired.
+  resolutionAction?: ReportResolutionAction
   // Owner is required to fix and resubmit the listing (-> REVISION_REQUIRED).
   // Mutually exclusive with removeListing.
   ownerActionRequired?: boolean

--- a/src/components/features/reports/reports-page.tsx
+++ b/src/components/features/reports/reports-page.tsx
@@ -116,6 +116,7 @@ const ViolationReportManagement = () => {
       await ListingService.resolveReport(selectedReport.reportId, {
         status: 'RESOLVED',
         adminNotes: reason,
+        resolutionAction: 'REVISION_REQUESTED',
       })
 
       toast.success(t('toasts.revisionSuccess'))

--- a/src/components/organisms/reports/ReportReviewModal.tsx
+++ b/src/components/organisms/reports/ReportReviewModal.tsx
@@ -31,9 +31,15 @@ import {
   ShieldCheck,
 } from 'lucide-react'
 import cn from 'classnames'
-import { ListingReport } from '@/api/types/listing-report.type'
+import {
+  ListingReport,
+  ReportResolutionAction,
+} from '@/api/types/listing-report.type'
 import { ListingService } from '@/api/services/listing.service'
-import { ListingResponseWithAdmin } from '@/api/types/listing.type'
+import {
+  ListingResponseWithAdmin,
+  ModerationStatus,
+} from '@/api/types/listing.type'
 import { toast } from 'sonner'
 import { formatPrice, formatDateTimeParts } from '@/utils/format'
 
@@ -81,6 +87,65 @@ const statusMap = {
   PENDING: 'pending',
   RESOLVED: 'resolved',
   REJECTED: 'dismissed',
+}
+
+// What action the admin actually took on the reported listing. Newer reports
+// carry the persisted `resolutionAction`; older rows (resolved before it was
+// tracked) fall back to inferring it from the listing's current moderationStatus.
+// Returns null while still pending.
+type ReportOutcome = 'suspended' | 'revision' | 'dismissed' | 'resolved'
+
+const RESOLUTION_ACTION_TO_OUTCOME: Record<
+  ReportResolutionAction,
+  ReportOutcome
+> = {
+  SUSPENDED: 'suspended',
+  REVISION_REQUESTED: 'revision',
+  DISMISSED: 'dismissed',
+  RESOLVED: 'resolved',
+}
+
+const getReportOutcome = (
+  status: string,
+  resolutionAction: ReportResolutionAction | null | undefined,
+  moderationStatus: ModerationStatus | null | undefined,
+): ReportOutcome | null => {
+  if (status === 'PENDING') return null
+  // Prefer the action the backend recorded at resolution time.
+  if (resolutionAction) return RESOLUTION_ACTION_TO_OUTCOME[resolutionAction]
+  // Legacy rows (no persisted action) — infer from status + moderation status.
+  if (status === 'REJECTED') return 'dismissed'
+  if (moderationStatus === 'SUSPENDED' || moderationStatus === 'REMOVED')
+    return 'suspended'
+  if (moderationStatus === 'REVISION_REQUIRED') return 'revision'
+  return 'resolved'
+}
+
+const getOutcomeColor = (outcome: ReportOutcome) => {
+  switch (outcome) {
+    case 'suspended':
+      return 'bg-destructive/10 text-destructive dark:bg-destructive/20 border-destructive/30'
+    case 'revision':
+      return 'bg-warning/10 text-warning-foreground dark:bg-warning/20 border-warning/30'
+    case 'resolved':
+      return 'bg-success/10 text-success-foreground dark:bg-success/20 border-success/30'
+    default:
+      return 'bg-muted text-muted-foreground border-border/70'
+  }
+}
+
+const getOutcomeIcon = (outcome: ReportOutcome) => {
+  const cls = 'h-3.5 w-3.5'
+  switch (outcome) {
+    case 'suspended':
+      return <Ban className={cls} />
+    case 'revision':
+      return <Edit className={cls} />
+    case 'resolved':
+      return <CheckCircle className={cls} />
+    default:
+      return <XCircle className={cls} />
+  }
 }
 
 const getPropertyIcon = (type: string) => {
@@ -157,6 +222,7 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
         status: 'RESOLVED',
         adminNotes: actionReason,
         removeListing: true,
+        resolutionAction: 'SUSPENDED',
       })
       if (!response.success) {
         toast.error(response.message || t('toasts.removeListingError'))
@@ -186,6 +252,7 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
       const response = await ListingService.resolveReport(report.reportId, {
         status: 'REJECTED',
         adminNotes: actionReason,
+        resolutionAction: 'DISMISSED',
       })
       if (!response.success) {
         toast.error(response.message || t('toasts.dismissError'))
@@ -288,6 +355,15 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
     }
   }
 
+  // Resolution outcome badge — what happened to the listing once handled.
+  const reportOutcome = report
+    ? getReportOutcome(
+        report.status,
+        report.resolutionAction,
+        listingDetails?.moderationStatus,
+      )
+    : null
+
   // Owner of the reported listing — surfaced so admins can contact directly.
   const owner = listingDetails?.user ?? null
   const ownerName = owner
@@ -338,6 +414,27 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                           </>
                         )}
                       </p>
+                      {reportOutcome &&
+                        !(
+                          report.status === 'RESOLVED' &&
+                          !report.resolutionAction &&
+                          loadingListing
+                        ) && (
+                          <div className='mt-2 flex flex-wrap items-center gap-2'>
+                            <span className='text-xs md:text-sm opacity-90'>
+                              {t('review.resolutionAction')}
+                            </span>
+                            <Badge
+                              className={cn(
+                                'inline-flex items-center gap-1 text-xs',
+                                getOutcomeColor(reportOutcome),
+                              )}
+                            >
+                              {getOutcomeIcon(reportOutcome)}
+                              {t(`review.outcomes.${reportOutcome}`)}
+                            </Badge>
+                          </div>
+                        )}
                     </div>
                     <Badge
                       className={cn(

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2037,6 +2037,13 @@
       "direction": "Direction",
       "location": "Location",
       "listingStatus": "Listing Status:",
+      "resolutionAction": "Resolution:",
+      "outcomes": {
+        "suspended": "Listing Suspended",
+        "revision": "Revision Requested",
+        "dismissed": "Dismissed",
+        "resolved": "Resolved"
+      },
       "verified": "Verified",
       "pendingVerification": "Pending Verification",
       "expired": "Expired",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2001,6 +2001,13 @@
       "direction": "Hướng",
       "location": "Địa điểm",
       "listingStatus": "Trạng thái bài đăng:",
+      "resolutionAction": "Kết quả xử lý:",
+      "outcomes": {
+        "suspended": "Đình Chỉ Tin Đăng",
+        "revision": "Yêu Cầu Sửa Đổi",
+        "dismissed": "Bỏ Qua",
+        "resolved": "Đã Xử Lý"
+      },
       "verified": "Đã xác thực",
       "pendingVerification": "Chờ xác thực",
       "expired": "Đã hết hạn",


### PR DESCRIPTION
## Vấn đề

Trong dialog **Xem Xét Báo Cáo Vi Phạm**, khi report đã xử lý xong thì không thấy được listing bị xử lý ra sao — đình chỉ, yêu cầu sửa đổi, hay bỏ qua. `report.status` chỉ có `PENDING`/`RESOLVED`/`REJECTED` và cả "đình chỉ" lẫn "yêu cầu sửa đổi" đều là `RESOLVED`.

## Thay đổi

Thêm badge **"Kết quả xử lý"** ở đầu dialog (hiện khi report không còn chờ xử lý):

| Badge | Khi nào |
|---|---|
| 🚫 Đình Chỉ Tin Đăng | `SUSPENDED` |
| ✏️ Yêu Cầu Sửa Đổi | `REVISION_REQUESTED` |
| ✖ Bỏ Qua | `DISMISSED` |
| ✔ Đã Xử Lý | `RESOLVED` (chung/legacy) |

- 3 nút xử lý gửi `resolutionAction` tường minh (đình chỉ → `SUSPENDED`, bỏ qua → `DISMISSED`, yêu cầu sửa đổi → `REVISION_REQUESTED`).
- Badge **ưu tiên `report.resolutionAction`** do backend lưu; report cũ (chưa có field) thì fallback suy từ `moderationStatus` hiện tại của listing.
- Thêm i18n `reports.review.resolutionAction` + `reports.review.outcomes.*` (vi/en).

## Kiểm tra

`tsc --noEmit` + `eslint` + `prettier` — sạch. i18n keys hợp lệ ở cả vi/en.

> ⚠️ **Phụ thuộc backend PR** `feat/report-resolution-action` (smartrent-backend #438): cần deploy để có field `resolutionAction` + migration V116. Trước khi merge BE, badge vẫn chạy bằng nhánh fallback (suy từ moderationStatus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
