### PR TITLE
fix(posts): remove field line, stop badge floating when category is h…

### DIFF
--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -508,7 +508,12 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                     key={i}
                     className='rounded-lg border border-destructive/30 bg-destructive/10 dark:bg-destructive/20 p-3'
                   >
-                    <div className='flex items-center justify-between gap-2'>
+                    <div
+                      className={cn(
+                        'flex items-center gap-2',
+                        isMeaningful(v.category) && 'justify-between',
+                      )}
+                    >
                       {isMeaningful(v.category) && (
                         <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
                           {v.category}
@@ -517,7 +522,8 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                       <Badge
                         variant='outline'
                         className={cn(
-                          'ml-auto shrink-0 text-xs',
+                          'shrink-0 text-xs',
+                          isMeaningful(v.category) && 'ml-auto',
                           getSeverityColor(v.severity),
                         )}
                       >
@@ -527,11 +533,6 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                     <p className='mt-1 break-words text-sm text-foreground/80'>
                       {v.message}
                     </p>
-                    {isMeaningful(v.field) && (
-                      <p className='mt-0.5 break-words text-xs text-muted-foreground'>
-                        {t('aiAnalysis.field')}: {v.field}
-                      </p>
-                    )}
                   </div>
                 ))}
               </div>
@@ -551,7 +552,12 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                     key={i}
                     className='rounded-lg border border-warning/30 bg-warning/10 dark:bg-warning/20 p-3'
                   >
-                    <div className='flex items-center justify-between gap-2'>
+                    <div
+                      className={cn(
+                        'flex items-center gap-2',
+                        isMeaningful(s.category) && 'justify-between',
+                      )}
+                    >
                       {isMeaningful(s.category) && (
                         <span className='min-w-0 flex-1 truncate text-sm font-medium text-foreground'>
                           {s.category}
@@ -560,7 +566,8 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                       <Badge
                         variant='outline'
                         className={cn(
-                          'ml-auto shrink-0 text-xs',
+                          'shrink-0 text-xs',
+                          isMeaningful(s.category) && 'ml-auto',
                           getSeverityColor(s.priority),
                         )}
                       >
@@ -570,11 +577,6 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                     <p className='mt-1 break-words text-sm text-foreground/80'>
                       {s.message}
                     </p>
-                    {isMeaningful(s.field) && (
-                      <p className='mt-0.5 break-words text-xs text-muted-foreground'>
-                        {t('aiAnalysis.field')}: {s.field}
-                      </p>
-                    )}
                   </div>
                 ))}
               </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1877,7 +1877,6 @@
       "missingFields": "Missing",
       "violations": "Violations",
       "suggestions": "Suggestions",
-      "field": "Field",
       "advisoryNote": "This AI assessment is advisory only — the moderation decision remains with you.",
       "suggested": {
         "APPROVED": "Approve",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1841,7 +1841,6 @@
       "missingFields": "Thiếu",
       "violations": "Vi phạm",
       "suggestions": "Gợi ý",
-      "field": "Trường",
       "advisoryNote": "Đánh giá AI chỉ mang tính tham khảo — quyết định kiểm duyệt vẫn thuộc về bạn.",
       "suggested": {
         "APPROVED": "Duyệt",


### PR DESCRIPTION
…idden

- Drop the "Trường: {field}" line from violations/suggestions entirely — it added little value and cluttered the card.
- justify-between + a hardcoded ml-auto pushed the severity/priority badge ("Thấp", "Trung bình") to sit alone at the far right with a large empty gap whenever the category was hidden (e.g. the AI's generic "unknown"/ "improvement" placeholder). Only apply justify-between/ml-auto when a category is actually shown, so a lone badge sits naturally at the start instead of stranded on the right.