### PR TITLE
fix(nav): drop "chờ duyệt" from broker-pending breadcrumb label

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -233,7 +233,7 @@ const LABELS = {
       admins: 'Quản trị viên',
       roles: 'Vai trò',
       transactions: 'Giao dịch',
-      brokerPending: 'Đơn đăng ký môi giới chờ duyệt',
+      brokerPending: 'Đơn đăng ký môi giới',
       premiumMembership: 'Thành viên',
       premiumListingTypes: 'Loại tin đăng',
       analyticsUsers: 'Thống kê người dùng',


### PR DESCRIPTION
## Thay đổi

Breadcrumb trang **Kiểm duyệt › Đơn đăng ký môi giới chờ duyệt** hơi dài. Bỏ chữ "chờ duyệt" khỏi nhãn `brokerPending` trong `navigation.ts` → breadcrumb còn **Kiểm duyệt › Đơn đăng ký môi giới**.

Đây là nguồn của cả breadcrumb lẫn nhãn sidebar cho route `/moderation/broker-pending`. Chỉ đổi bản tiếng Việt (bản EN "Pending Broker Applications" giữ nguyên).