### PR TITLE
Add name/email/phone search to broker-pending admin page

### DIFF
--- a/src/api/services/broker.service.ts
+++ b/src/api/services/broker.service.ts
@@ -20,6 +20,7 @@ export class BrokerService {
   static async getPendingBrokers(params?: {
     page?: number
     size?: number
+    keyword?: string
   }): Promise<ApiResponse<PaginatedResponse<AdminBrokerUserResponse>>> {
     return apiRequest<PaginatedResponse<AdminBrokerUserResponse>>({
       method: 'GET',

--- a/src/components/features/brokers/broker-pending-page.tsx
+++ b/src/components/features/brokers/broker-pending-page.tsx
@@ -17,6 +17,7 @@ type ActionKind = 'approve' | 'reject' | 'remove'
 type BrokerFilterValues = {
   page: number
   pageSize: number
+  keyword?: string
 }
 
 const BrokerPendingPage = () => {
@@ -82,9 +83,11 @@ const BrokerPendingPage = () => {
     setError(null)
 
     try {
+      const keyword = filterValues.keyword?.trim()
       const response = await BrokerService.getPendingBrokers({
         page: filterValues.page,
         size: filterValues.pageSize,
+        keyword: keyword || undefined,
       })
 
       if (response.success && response.data) {
@@ -112,7 +115,7 @@ const BrokerPendingPage = () => {
     } finally {
       setLoading(false)
     }
-  }, [filterValues.page, filterValues.pageSize, t])
+  }, [filterValues.page, filterValues.pageSize, filterValues.keyword, t])
 
   useEffect(() => {
     fetchPendingBrokers()

--- a/src/components/organisms/brokers/BrokerPendingTable.tsx
+++ b/src/components/organisms/brokers/BrokerPendingTable.tsx
@@ -3,7 +3,7 @@
 import React from 'react'
 import { useTranslations } from 'next-intl'
 import { Eye } from 'lucide-react'
-import { DataTable, Column } from '@/components/organisms/DataTable'
+import { DataTable, Column, FilterConfig } from '@/components/organisms/DataTable'
 import { Button } from '@/components/atoms/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/atoms/avatar'
 import { AdminBrokerUserResponse } from '@/api/types/broker.type'
@@ -97,10 +97,22 @@ export const BrokerPendingTable: React.FC<BrokerPendingTableProps> = ({
   const pageSize =
     typeof filterValues.pageSize === 'number' ? filterValues.pageSize : 10
 
+  const filterConfig: FilterConfig[] = [
+    {
+      // Backend OR-combines this against name/email/phone, so a single box
+      // searches all three at once.
+      id: 'keyword',
+      type: 'search',
+      label: t('filters.searchPlaceholder'),
+      placeholder: t('filters.searchPlaceholder'),
+    },
+  ]
+
   return (
     <DataTable
       data={data}
       columns={columns}
+      filters={filterConfig}
       filterMode='api'
       filterValues={filterValues}
       onFilterChange={onFilterChange}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2275,6 +2275,9 @@
         },
         "verifyLink": "Verify on official registry ↗"
       },
+      "filters": {
+        "searchPlaceholder": "Search by name, email, or phone..."
+      },
       "documents": {
         "cccdFront": "CCCD - Front",
         "cccdBack": "CCCD - Back",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2239,6 +2239,9 @@
         },
         "verifyLink": "Xác minh trên cổng chính thức ↗"
       },
+      "filters": {
+        "searchPlaceholder": "Tìm theo tên, email hoặc số điện thoại..."
+      },
       "documents": {
         "cccdFront": "CCCD - Mặt trước",
         "cccdBack": "CCCD - Mặt sau",


### PR DESCRIPTION
Admins reviewing pending broker applications had no way to search the list. Adds a debounced search box that queries name/email/phone together via the backend's new keyword param.