### PR TITLE
fix: disable Vercel image optimization to stop 402s on listing photos

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,12 @@ const nextConfig: NextConfig = {
   reactStrictMode: false,
   basePath: process.env.NEXT_PUBLIC_BASE_PATH || '',
   images: {
+    // Admin is an internal review tool, not the SEO/perf-critical public
+    // site — skip Vercel's paid Image Optimization API entirely so listing
+    // photos always render straight from their origin (R2/CDN) instead of
+    // occasionally 402ing ("Payment Required") once the account's optimized-
+    // image quota for the month is used up.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
Testing the mobile review-dialog fix surfaced a real bug: listing photos silently failed (showed only the alt text) whenever the app requested an image size/quality variant Vercel hadn't optimized and cached yet — the optimizer responded 402 Payment Required once the account's monthly Image Optimization quota ran out. Desktop happened to hit already-cached variants, so it looked mobile-only.

Admin is an internal review tool, not the SEO/perf-critical public site (smartrent-fe), so there's no real payoff in routing photos through Vercel's paid optimizer. Set images.unoptimized so listing photos load straight from their origin (R2/CDN) and can never hit that quota wall.