### PR TITLE
feat(reports): open owner contact via Zalo instead of tel:

### DIFF
--- a/src/components/organisms/reports/ReportReviewModal.tsx
+++ b/src/components/organisms/reports/ReportReviewModal.tsx
@@ -553,7 +553,9 @@ export const ReportReviewModal: React.FC<ReportReviewModalProps> = ({
                           {owner.contactPhoneNumber && (
                             <div className='flex flex-wrap items-center gap-x-2 gap-y-0.5'>
                               <a
-                                href={`tel:${owner.contactPhoneNumber}`}
+                                href={`https://zalo.me/${owner.contactPhoneNumber.replace(/\D/g, '')}`}
+                                target='_blank'
+                                rel='noopener noreferrer'
                                 className='flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-primary'
                               >
                                 <Phone className='h-3.5 w-3.5 shrink-0' />


### PR DESCRIPTION
## What
In the **Report Review** modal, the reported listing owner's phone link opened a `tel:` dialer. It now opens a **Zalo chat** — `https://zalo.me/<digits>`, in a new tab — matching the Zalo contact convention used across the platform and shipped by the backend (`ownerZaloLink` / support `zaloLink`).

## Change
- `ReportReviewModal`: owner contact phone `<a>` → `https://zalo.me/<digits-only>` with `target="_blank" rel="noopener noreferrer"`. The number text and verified badge are unchanged.

## Verification
- `eslint` on the file ✅ (0 errors) · `tsc --noEmit` ✅

Branched fresh off `origin/main`.