### PR TITLE
fix: keep broker review dialog open when navigating lightbox images

### DIFF
--- a/src/components/organisms/brokers/BrokerReviewDialog.tsx
+++ b/src/components/organisms/brokers/BrokerReviewDialog.tsx
@@ -150,7 +150,14 @@ export const BrokerReviewDialog: React.FC<BrokerReviewDialogProps> = ({
   return (
     <>
       <Dialog open={open} onOpenChange={handleClose}>
-        <DialogContent className='flex w-[80vw] max-w-[1200px] mx-auto max-h-[90vh] flex-col overflow-hidden p-0 gap-0'>
+        <DialogContent
+          className='flex w-[80vw] max-w-[1200px] mx-auto max-h-[90vh] flex-col overflow-hidden p-0 gap-0'
+          onPointerDownOutside={(event) => {
+            if (lightboxIndex !== null) {
+              event.preventDefault()
+            }
+          }}
+        >
           <>
             {/* Fixed header */}
             <DialogHeader className='shrink-0 border-b border-border/60 px-6 py-4'>


### PR DESCRIPTION
The lightbox overlay renders outside Radix DialogContent, so clicking the prev/next arrows registered as an outside pointerdown and closed the whole review dialog instead of switching images.