### PR TITLE
feat: search and filter posts by listing ID

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -263,8 +263,10 @@ export interface ListingFilterRequest {
   size?: number
   sortBy?: 'DEFAULT' | 'PRICE_ASC' | 'PRICE_DESC' | 'NEWEST' | 'OLDEST'
   sortDirection?: 'ASC' | 'DESC'
-  /** Legacy: search in title and description. Prefer `title` and `ownerSearch`. */
+  /** Legacy: search in title and description. Prefer `title` and `ownerSearch`. A purely-numeric keyword also matches the listing ID exactly. */
   keyword?: string
+  /** Exact match on listing ID (PK lookup). */
+  id?: number
   /** Case-insensitive substring match on the listing title only. */
   title?: string
   /** Matches owner firstName/lastName/contactPhoneNumber/phoneNumber (case-insensitive contains). */

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -223,6 +223,13 @@ export const PostTable: React.FC<PostTableProps> = ({
       placeholder: t('filters.searchPlaceholder'),
     },
     {
+      id: 'id',
+      type: 'search',
+      label: t('filters.idSearch'),
+      placeholder: t('filters.idSearchPlaceholder'),
+      isFilterField: true,
+    },
+    {
       id: 'title',
       type: 'search',
       label: t('filters.titleSearch'),

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1713,7 +1713,7 @@
       "placeholder": "Search by title, poster name, or address..."
     },
     "filters": {
-      "searchPlaceholder": "Search by title, address, or description…",
+      "searchPlaceholder": "Search by title, address, description, or listing ID…",
       "status": "Status",
       "pending": "Pending",
       "approved": "Approved",
@@ -1729,6 +1729,8 @@
       "forRent": "For Rent",
       "share": "Share",
       "pickDateRange": "Pick a date range",
+      "idSearch": "Listing ID",
+      "idSearchPlaceholder": "Enter listing ID",
       "titleSearch": "Title",
       "titleSearchPlaceholder": "Search by title",
       "ownerSearch": "Owner",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1677,7 +1677,7 @@
       "placeholder": "Tìm theo tiêu đề, tên người đăng hoặc địa chỉ..."
     },
     "filters": {
-      "searchPlaceholder": "Tìm theo tiêu đề, địa chỉ, mô tả…",
+      "searchPlaceholder": "Tìm theo tiêu đề, địa chỉ, mô tả, ID tin đăng…",
       "status": "Trạng Thái",
       "pending": "Chờ Duyệt",
       "approved": "Đã Duyệt",
@@ -1693,6 +1693,8 @@
       "forRent": "Cho Thuê",
       "share": "Chia Sẻ",
       "pickDateRange": "Chọn khoảng thời gian",
+      "idSearch": "ID tin đăng",
+      "idSearchPlaceholder": "Nhập ID tin đăng",
       "titleSearch": "Tiêu đề",
       "titleSearchPlaceholder": "Tìm theo tiêu đề",
       "ownerSearch": "Chủ tin",

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -164,9 +164,16 @@ export const mapUIFiltersToAPI = (
   }
 
   // Search keyword (new `keyword` id, backward compatible with legacy `search`)
+  // A purely-numeric keyword also matches the listing ID directly (server-side).
   const keyword = str('keyword') ?? str('search')
   if (keyword) {
     apiFilters.keyword = keyword
+  }
+
+  // Exact listing ID filter (advanced filter dialog)
+  const id = num('id')
+  if (id !== undefined) {
+    apiFilters.id = id
   }
 
   // moderationStatus filter (primary moderation workflow field)


### PR DESCRIPTION
The admin quick-search box now also matches a listing by exact ID when the typed term is numeric (backend already handles this transparently), and adds a dedicated "ID tin đăng" field to the advanced filter dialog for exact-match filtering.