### PR TITLE
fix: populate poster avatar in listing detail mapper

### DIFF
--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -444,7 +444,7 @@ export const mapDetailToUI = (item: ListingResponseWithAdmin): UIPostData => {
       name: item.user
         ? `${item.user.firstName} ${item.user.lastName}`
         : 'Unknown User',
-      avatar: undefined,
+      avatar: item.user?.avatarUrl ?? undefined,
       userId: item.user?.userId || '',
       phone: item.user?.contactPhoneNumber || '',
       email: item.user?.email || undefined,


### PR DESCRIPTION
mapDetailToUI hardcoded poster.avatar to undefined even though ListingUser.avatarUrl is returned by the API, so the review modal always showed initials instead of the real avatar. InitialsAvatar already falls back gracefully when the image fails to load.