### PR TITLE
fix: align preview layout (badge/title/image order) with fe article page

### DIFF
--- a/src/components/features/news/news-editor-page.tsx
+++ b/src/components/features/news/news-editor-page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useEffect, useMemo, useRef } from 'react'
+import NextImage from 'next/image'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useTranslations } from 'next-intl'
 import { useEditor, EditorContent } from '@tiptap/react'
@@ -24,7 +25,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 import { toast } from 'sonner'
 import slugify from 'react-slugify'
-import { Loader2 } from 'lucide-react'
+import { ImageOff, Loader2 } from 'lucide-react'
 import { NewsService } from '@/api/services/news.service'
 import { NewsCreateRequest, NewsUpdateRequest } from '@/api/types/news.type'
 import { EditorFormData } from '@/types/news-editor.type'
@@ -32,7 +33,15 @@ import type { Resolver } from 'react-hook-form'
 import { NewsEditorMenuBar } from '@/components/molecules/editor/NewsEditorMenuBar'
 import { NewsEditorHeader } from '@/components/organisms/news/NewsEditorHeader'
 import { NewsMetaForm } from '@/components/organisms/news/NewsMetaForm'
+import { Badge } from '@/components/atoms/badge'
+import { cn } from '@/lib/utils'
 import { sanitizeHtml } from '@/utils/sanitize-html'
+import {
+  getCategoryBadgeClass,
+  ARTICLE_TITLE_CLASS,
+  ARTICLE_IMAGE_CONTAINER_CLASS,
+  isValidImageSrc,
+} from '@/utils/news-style'
 
 const SUCCESS_CODE = '999999'
 
@@ -40,6 +49,7 @@ const NewsEditor = () => {
   const router = useRouter()
   const searchParams = useSearchParams()
   const t = useTranslations('news.editor')
+  const tNews = useTranslations('news')
   const idParam = searchParams?.get('id')
   const newsId = idParam ? Number(idParam) : null
   const isEditMode = newsId !== null && !Number.isNaN(newsId)
@@ -102,6 +112,12 @@ const NewsEditor = () => {
   })
 
   const title = watch('title')
+  const previewSummary = watch('summary')
+  const previewCategory = watch('category')
+  const previewThumbnailUrl = watch('thumbnailUrl')
+  const safePreviewThumbnailSrc = isValidImageSrc(previewThumbnailUrl)
+    ? previewThumbnailUrl
+    : null
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -440,12 +456,44 @@ const NewsEditor = () => {
                 </>
               ) : (
                 <div className='bg-muted/40 p-6 sm:p-10'>
-                  <div className='mx-auto max-w-4xl rounded-xl border border-border/60 bg-card p-8 shadow-sm sm:p-12'>
-                    <h2 className='mb-6 inline-block border-b-2 border-primary pb-3 text-3xl font-semibold tracking-tight text-foreground sm:text-4xl'>
-                      {watch('title')}
-                    </h2>
+                  <div className='mx-auto max-w-4xl space-y-5 rounded-xl border border-border/60 bg-card p-8 shadow-sm sm:p-12'>
+                    <Badge
+                      variant='outline'
+                      className={cn(
+                        'border-transparent',
+                        getCategoryBadgeClass(previewCategory),
+                      )}
+                    >
+                      {tNews(`category.${previewCategory}`)}
+                    </Badge>
+
+                    <h2 className={ARTICLE_TITLE_CLASS}>{title}</h2>
+
+                    {previewSummary && (
+                      <p className='text-base leading-relaxed text-muted-foreground'>
+                        {previewSummary}
+                      </p>
+                    )}
+
                     <div
-                      className='news-article-content mt-6 max-w-none'
+                      className={cn(ARTICLE_IMAGE_CONTAINER_CLASS, 'bg-muted')}
+                    >
+                      {safePreviewThumbnailSrc ? (
+                        <NextImage
+                          src={safePreviewThumbnailSrc}
+                          alt={title}
+                          fill
+                          className='object-cover'
+                        />
+                      ) : (
+                        <div className='flex h-full w-full items-center justify-center text-muted-foreground/60'>
+                          <ImageOff className='h-10 w-10' />
+                        </div>
+                      )}
+                    </div>
+
+                    <div
+                      className='news-article-content max-w-none'
                       dangerouslySetInnerHTML={{
                         __html: sanitizeHtml(editor?.getHTML() || ''),
                       }}

--- a/src/components/organisms/news/NewsPreviewModal.tsx
+++ b/src/components/organisms/news/NewsPreviewModal.tsx
@@ -9,48 +9,22 @@ import {
 } from '@/components/atoms/dialog'
 import { Badge } from '@/components/atoms/badge'
 import { Calendar, User, Eye, Tag, ImageOff } from 'lucide-react'
-import { NewsResponse, NewsStatus, NewsCategory } from '@/api/types/news.type'
+import { NewsResponse } from '@/api/types/news.type'
 import { cn } from '@/lib/utils'
 import { formatDateTime } from '@/utils/format'
 import { sanitizeHtml } from '@/utils/sanitize-html'
+import {
+  getCategoryBadgeClass,
+  getStatusBadgeClass,
+  ARTICLE_TITLE_CLASS,
+  ARTICLE_IMAGE_CONTAINER_CLASS,
+  isValidImageSrc,
+} from '@/utils/news-style'
 
 interface NewsPreviewModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   news: NewsResponse | null
-}
-
-const getStatusClass = (status: NewsStatus): string => {
-  const colors: Record<NewsStatus, string> = {
-    DRAFT: 'border-warning/30 bg-warning/15 text-warning-foreground',
-    PUBLISHED: 'border-success/30 bg-success/12 text-success-foreground',
-    ARCHIVED: 'border-border bg-muted text-foreground/70',
-  }
-  return colors[status]
-}
-
-const getCategoryClass = (category: NewsCategory): string => {
-  const colors: Record<NewsCategory, string> = {
-    NEWS: 'border-blue-200/70 bg-blue-50 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/10 dark:text-blue-300',
-    BLOG: 'border-purple-200/70 bg-purple-50 text-purple-700 dark:border-purple-500/30 dark:bg-purple-500/10 dark:text-purple-300',
-    POLICY:
-      'border-orange-200/70 bg-orange-50 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300',
-    MARKET:
-      'border-emerald-200/70 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300',
-    PROJECT:
-      'border-cyan-200/70 bg-cyan-50 text-cyan-700 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:text-cyan-300',
-    INVESTMENT:
-      'border-indigo-200/70 bg-indigo-50 text-indigo-700 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-300',
-    GUIDE:
-      'border-pink-200/70 bg-pink-50 text-pink-700 dark:border-pink-500/30 dark:bg-pink-500/10 dark:text-pink-300',
-  }
-  return colors[category]
-}
-
-const isValidImageSrc = (src: unknown): src is string => {
-  if (typeof src !== 'string') return false
-  const normalized = src.trim()
-  return normalized.startsWith('/') || /^https?:\/\//i.test(normalized)
 }
 
 const MetaItem: React.FC<{
@@ -90,27 +64,14 @@ export const NewsPreviewModal: React.FC<NewsPreviewModalProps> = ({
 
         {news && (
           <div className='min-h-0 flex-1 overflow-y-auto'>
-            {/* Thumbnail or placeholder */}
-            <div className='relative h-56 w-full overflow-hidden bg-muted sm:h-64'>
-              {safeThumbnailSrc ? (
-                <Image
-                  src={safeThumbnailSrc}
-                  alt={news.title}
-                  fill
-                  className='object-cover'
-                />
-              ) : (
-                <div className='flex h-full w-full items-center justify-center text-muted-foreground/60'>
-                  <ImageOff className='h-10 w-10' />
-                </div>
-              )}
-              <div className='absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/55 via-black/15 to-transparent p-5'>
+            <article className='space-y-5 px-6 py-6'>
+              <header className='space-y-3'>
                 <div className='flex flex-wrap items-center gap-1.5'>
                   <Badge
                     variant='outline'
                     className={cn(
-                      'border-transparent backdrop-blur',
-                      getCategoryClass(news.category),
+                      'border-transparent',
+                      getCategoryBadgeClass(news.category),
                     )}
                   >
                     {t(`category.${news.category}`)}
@@ -118,22 +79,23 @@ export const NewsPreviewModal: React.FC<NewsPreviewModalProps> = ({
                   <Badge
                     variant='outline'
                     className={cn(
-                      'border-transparent backdrop-blur',
-                      getStatusClass(news.status),
+                      'border-transparent',
+                      getStatusBadgeClass(news.status),
                     )}
                   >
                     {t(`status.${news.status}`)}
                   </Badge>
                 </div>
-              </div>
-            </div>
 
-            <article className='space-y-5 px-6 py-6'>
-              <header className='space-y-3'>
-                <h2 className='text-2xl font-semibold leading-tight tracking-tight text-foreground'>
-                  {news.title}
-                </h2>
-                <div className='flex flex-wrap gap-x-4 gap-y-1.5'>
+                <h2 className={ARTICLE_TITLE_CLASS}>{news.title}</h2>
+
+                {news.summary && (
+                  <p className='text-base leading-relaxed text-muted-foreground'>
+                    {news.summary}
+                  </p>
+                )}
+
+                <div className='flex flex-wrap gap-x-4 gap-y-1.5 border-y border-border/60 py-3'>
                   <MetaItem icon={User}>
                     {news.authorName || t('notAvailable')}
                   </MetaItem>
@@ -146,11 +108,21 @@ export const NewsPreviewModal: React.FC<NewsPreviewModalProps> = ({
                 </div>
               </header>
 
-              {news.summary && (
-                <blockquote className='rounded-lg border-l-2 border-primary/60 bg-muted/40 px-4 py-3 text-sm italic leading-relaxed text-foreground/80'>
-                  {news.summary}
-                </blockquote>
-              )}
+              {/* Featured Image */}
+              <div className={cn(ARTICLE_IMAGE_CONTAINER_CLASS, 'bg-muted')}>
+                {safeThumbnailSrc ? (
+                  <Image
+                    src={safeThumbnailSrc}
+                    alt={news.title}
+                    fill
+                    className='object-cover'
+                  />
+                ) : (
+                  <div className='flex h-full w-full items-center justify-center text-muted-foreground/60'>
+                    <ImageOff className='h-10 w-10' />
+                  </div>
+                )}
+              </div>
 
               <div
                 className='news-article-content max-w-none'

--- a/src/utils/news-style.ts
+++ b/src/utils/news-style.ts
@@ -1,0 +1,42 @@
+import { NewsCategory, NewsStatus } from '@/api/types/news.type'
+
+export const getCategoryBadgeClass = (category: NewsCategory): string => {
+  const colors: Record<NewsCategory, string> = {
+    NEWS: 'border-blue-200/70 bg-blue-50 text-blue-700 dark:border-blue-500/30 dark:bg-blue-500/10 dark:text-blue-300',
+    BLOG: 'border-purple-200/70 bg-purple-50 text-purple-700 dark:border-purple-500/30 dark:bg-purple-500/10 dark:text-purple-300',
+    POLICY:
+      'border-orange-200/70 bg-orange-50 text-orange-700 dark:border-orange-500/30 dark:bg-orange-500/10 dark:text-orange-300',
+    MARKET:
+      'border-emerald-200/70 bg-emerald-50 text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300',
+    PROJECT:
+      'border-cyan-200/70 bg-cyan-50 text-cyan-700 dark:border-cyan-500/30 dark:bg-cyan-500/10 dark:text-cyan-300',
+    INVESTMENT:
+      'border-indigo-200/70 bg-indigo-50 text-indigo-700 dark:border-indigo-500/30 dark:bg-indigo-500/10 dark:text-indigo-300',
+    GUIDE:
+      'border-pink-200/70 bg-pink-50 text-pink-700 dark:border-pink-500/30 dark:bg-pink-500/10 dark:text-pink-300',
+  }
+  return colors[category]
+}
+
+export const getStatusBadgeClass = (status: NewsStatus): string => {
+  const colors: Record<NewsStatus, string> = {
+    DRAFT: 'border-warning/30 bg-warning/15 text-warning-foreground',
+    PUBLISHED: 'border-success/30 bg-success/12 text-success-foreground',
+    ARCHIVED: 'border-border bg-muted text-foreground/70',
+  }
+  return colors[status]
+}
+
+/** Matches fe's `Typography variant='pageTitle'` (text-title / md:text-title-lg). */
+export const ARTICLE_TITLE_CLASS =
+  'text-[1.375rem] leading-[1.75rem] md:text-[1.625rem] md:leading-[2rem] font-bold tracking-tight text-foreground'
+
+/** Matches fe's featured-image container in NewsDetailContent. */
+export const ARTICLE_IMAGE_CONTAINER_CLASS =
+  'relative aspect-video w-full overflow-hidden rounded-2xl shadow-sm ring-1 ring-border/10'
+
+export const isValidImageSrc = (src: unknown): src is string => {
+  if (typeof src !== 'string') return false
+  const normalized = src.trim()
+  return normalized.startsWith('/') || /^https?:\/\//i.test(normalized)
+}


### PR DESCRIPTION
Both admin preview entry points (listing "Preview" modal and the news editor's live-preview toggle) still diverged from fe's public article page in layout, not just typography: badges were overlaid on the thumbnail, the summary rendered as a blockquote, and the image came before the title/meta instead of after. Reorder both to match fe's NewsDetailHeader/NewsDetailContent: category+status badges above the title, title sized to match fe's pageTitle, summary as a plain paragraph, meta row, then the featured image, then body content. Shared badge-class and layout-class helpers extracted to src/utils/news-style.ts to avoid duplicating them across the two preview components.