### PR TITLE
feat: add load more pagination to admin notification dropdown

### DIFF
--- a/src/components/organisms/NotificationBell.tsx
+++ b/src/components/organisms/NotificationBell.tsx
@@ -15,9 +15,12 @@ export const NotificationBell: React.FC = () => {
     notifications,
     unreadCount,
     loading,
+    loadingMore,
+    hasMore,
     isConnected,
     markAsRead,
     markAllAsRead,
+    loadMore,
   } = useNotificationContext()
 
   const [isOpen, setIsOpen] = useState(false)
@@ -89,9 +92,12 @@ export const NotificationBell: React.FC = () => {
           <NotificationDropdown
             notifications={notifications}
             loading={loading}
+            loadingMore={loadingMore}
+            hasMore={hasMore}
             unreadCount={unreadCount}
             onMarkAsRead={markAsRead}
             onMarkAllAsRead={markAllAsRead}
+            onLoadMore={loadMore}
             onClose={handleClose}
           />
         </div>

--- a/src/components/organisms/NotificationDropdown.tsx
+++ b/src/components/organisms/NotificationDropdown.tsx
@@ -8,9 +8,12 @@ import { Loader2, CheckCheck, Bell } from 'lucide-react'
 interface NotificationDropdownProps {
   notifications: Notification[]
   loading: boolean
+  loadingMore: boolean
+  hasMore: boolean
   unreadCount: number
   onMarkAsRead: (id: number) => Promise<void>
   onMarkAllAsRead: () => Promise<void>
+  onLoadMore: () => Promise<void>
   onClose?: () => void
 }
 
@@ -21,9 +24,12 @@ interface NotificationDropdownProps {
 export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({
   notifications,
   loading,
+  loadingMore,
+  hasMore,
   unreadCount,
   onMarkAsRead,
   onMarkAllAsRead,
+  onLoadMore,
   onClose,
 }) => {
   const t = useTranslations('notifications')
@@ -76,6 +82,22 @@ export const NotificationDropdown: React.FC<NotificationDropdownProps> = ({
                 onClick={onClose}
               />
             ))}
+            {hasMore && (
+              <div className='flex justify-center py-3'>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  onClick={onLoadMore}
+                  disabled={loadingMore}
+                  className='text-xs text-muted-foreground hover:text-foreground'
+                >
+                  {loadingMore && (
+                    <Loader2 className='h-3.5 w-3.5 mr-1.5 animate-spin' />
+                  )}
+                  {t('loadMore', { defaultValue: 'Load more' })}
+                </Button>
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/contexts/notification/index.tsx
+++ b/src/contexts/notification/index.tsx
@@ -10,11 +10,14 @@ interface NotificationContextType {
   notifications: Notification[]
   unreadCount: number
   loading: boolean
+  loadingMore: boolean
+  hasMore: boolean
   error: string | null
   isConnected: boolean
   markAsRead: (id: number) => Promise<void>
   markAllAsRead: () => Promise<void>
   refetch: () => Promise<void>
+  loadMore: () => Promise<void>
 }
 
 const NotificationContext = createContext<NotificationContextType | undefined>(

--- a/src/hooks/useNotifications/index.tsx
+++ b/src/hooks/useNotifications/index.tsx
@@ -19,12 +19,17 @@ interface UseNotificationsReturn {
   notifications: Notification[]
   unreadCount: number
   loading: boolean
+  loadingMore: boolean
+  hasMore: boolean
   error: string | null
   isConnected: boolean
   markAsRead: (id: number) => Promise<void>
   markAllAsRead: () => Promise<void>
   refetch: () => Promise<void>
+  loadMore: () => Promise<void>
 }
+
+const PAGE_SIZE = 20
 
 /**
  * Hook for managing admin notifications with WebSocket (realtime) + REST API
@@ -47,6 +52,9 @@ export function useNotifications(
   const [notifications, setNotifications] = useState<Notification[]>([])
   const [unreadCount, setUnreadCount] = useState<number>(0)
   const [loading, setLoading] = useState<boolean>(false)
+  const [loadingMore, setLoadingMore] = useState<boolean>(false)
+  const [page, setPage] = useState<number>(0)
+  const [hasMore, setHasMore] = useState<boolean>(false)
   const [error, setError] = useState<string | null>(null)
   const [isConnected, setIsConnected] = useState<boolean>(false)
 
@@ -70,12 +78,14 @@ export function useNotifications(
       setError(null)
 
       const [notificationsRes, unreadCountRes] = await Promise.all([
-        NotificationService.fetchNotifications({ page: 0, size: 20 }),
+        NotificationService.fetchNotifications({ page: 0, size: PAGE_SIZE }),
         NotificationService.getUnreadCount(),
       ])
 
       if (notificationsRes.success && notificationsRes.data) {
         setNotifications(notificationsRes.data.data || [])
+        setPage(0)
+        setHasMore(notificationsRes.data.totalPages > 1)
       }
 
       if (unreadCountRes.success && unreadCountRes.data) {
@@ -90,6 +100,38 @@ export function useNotifications(
       setLoading(false)
     }
   }, [enabled, token])
+
+  /**
+   * Load the next page of older notifications and append them to the list
+   */
+  const loadMore = useCallback(async () => {
+    if (!enabled || !token || loadingMore || !hasMore) return
+
+    const nextPage = page + 1
+
+    try {
+      setLoadingMore(true)
+      setError(null)
+
+      const res = await NotificationService.fetchNotifications({
+        page: nextPage,
+        size: PAGE_SIZE,
+      })
+
+      if (res.success && res.data) {
+        setNotifications((prev) => [...prev, ...(res.data!.data || [])])
+        setPage(nextPage)
+        setHasMore(nextPage + 1 < res.data.totalPages)
+      }
+    } catch (err) {
+      const errorMsg =
+        err instanceof Error ? err.message : 'Failed to load more notifications'
+      setError(errorMsg)
+      console.error('Error loading more notifications:', err)
+    } finally {
+      setLoadingMore(false)
+    }
+  }, [enabled, token, loadingMore, hasMore, page])
 
   /**
    * Mark a notification as read
@@ -243,10 +285,13 @@ export function useNotifications(
     notifications,
     unreadCount,
     loading,
+    loadingMore,
+    hasMore,
     error,
     isConnected,
     markAsRead,
     markAllAsRead,
     refetch: fetchNotifications,
+    loadMore,
   }
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2477,6 +2477,7 @@
     "title": "Notifications",
     "markAllRead": "Mark all as read",
     "empty": "No notifications yet",
+    "loadMore": "Load more",
     "types": {
       "NEW_REPORT": "New Report",
       "LISTING_RESUBMITTED": "Listing Resubmitted",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2441,6 +2441,7 @@
     "title": "Thông báo",
     "markAllRead": "Đánh dấu tất cả đã đọc",
     "empty": "Chưa có thông báo",
+    "loadMore": "Xem thêm",
     "types": {
       "NEW_REPORT": "Báo cáo mới",
       "LISTING_RESUBMITTED": "Tin đăng gửi lại",


### PR DESCRIPTION
Notification dropdown only ever fetched the first 20 notifications on mount with no way to see older ones. Backend already returns totalPages, so wire up a "load more" button that fetches subsequent pages and appends them.