### PR TITLE
fix: rename admin nav label "Doanh thu" to "Thống kê doanh thu"

### DIFF
--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -238,7 +238,7 @@ const LABELS = {
       premiumListingTypes: 'Loại tin đăng',
       analyticsUsers: 'Thống kê người dùng',
       analyticsPosts: 'Thống kê tin đăng',
-      analyticsRevenue: 'Doanh thu',
+      analyticsRevenue: 'Thống kê doanh thu',
       analyticsReports: 'Thống kê báo cáo',
       posts: 'Tin đăng',
       news: 'Tin tức',


### PR DESCRIPTION
Aligns with sibling insights labels (analyticsUsers, analyticsPosts) which already use the "Thống kê" prefix.