### PR TITLE
fix: remove membership delete action and block dialog description

### DIFF
--- a/src/components/features/premium/premium-section-page.tsx
+++ b/src/components/features/premium/premium-section-page.tsx
@@ -6,7 +6,6 @@ import { toast } from 'sonner'
 import {
   getMembershipPackages,
   updateMembershipPackage,
-  deleteMembershipPackage,
 } from '@/api/services/membership.service'
 import { MembershipPackage as APIMembershipPackage } from '@/api/types/membership.type'
 import { VIPTierService } from '@/api/services/vip-tier.service'
@@ -15,7 +14,6 @@ import { MembershipPackage } from '@/types/premium.type'
 import { MembershipTable } from '../../organisms/premium/MembershipTable'
 import { ListingTypeTable } from '@/components/organisms/premium/ListingTypeTable'
 import { EditMembershipDialog } from '@/components/organisms/premium/EditMembershipDialog'
-import { DeleteMembershipDialog } from '@/components/organisms/premium/DeleteMembershipDialog'
 import { ViewMembershipDialog } from '@/components/organisms/premium/ViewMembershipDialog'
 import { useCanWrite } from '@/hooks/usePermissions'
 
@@ -48,10 +46,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
     null,
   )
   const [editSaving, setEditSaving] = useState(false)
-  const [deleteTarget, setDeleteTarget] = useState<APIMembershipPackage | null>(
-    null,
-  )
-  const [deleteSubmitting, setDeleteSubmitting] = useState(false)
 
   const needsMemberships = section === 'membership'
   const needsVIPTiers = section === 'listing-types'
@@ -141,11 +135,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
     if (pkg) setEditTarget(pkg)
   }
 
-  const handleDelete = (id: string) => {
-    const pkg = findApiPackage(id)
-    if (pkg) setDeleteTarget(pkg)
-  }
-
   const handleToggleStatus = async (id: string, currentStatus: string) => {
     const pkg = findApiPackage(id)
     if (!pkg) return
@@ -196,26 +185,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
     }
   }
 
-  const handleDeleteConfirm = async () => {
-    if (!deleteTarget) return
-    setDeleteSubmitting(true)
-    try {
-      const response = await deleteMembershipPackage(deleteTarget.membershipId)
-      if (response.success) {
-        toast.success(t('membership.toasts.deleteSuccess'))
-        setDeleteTarget(null)
-        await fetchMemberships()
-      } else {
-        toast.error(response.message || t('membership.toasts.deleteError'))
-      }
-    } catch (err) {
-      console.error('Delete membership error:', err)
-      toast.error(t('membership.toasts.deleteError'))
-    } finally {
-      setDeleteSubmitting(false)
-    }
-  }
-
   return (
     <div className='space-y-6'>
       {section === 'membership' && (
@@ -225,7 +194,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
             loading={membershipsLoading}
             onView={handleView}
             onEdit={handleEdit}
-            onDelete={handleDelete}
             onToggleStatus={handleToggleStatus}
             canWrite={canWrite}
           />
@@ -254,16 +222,6 @@ const PremiumSectionPage: React.FC<PremiumSectionPageProps> = ({ section }) => {
           if (!open) setEditTarget(null)
         }}
         onSubmit={handleEditSubmit}
-      />
-
-      <DeleteMembershipDialog
-        open={!!deleteTarget}
-        packageName={deleteTarget?.packageName}
-        loading={deleteSubmitting}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null)
-        }}
-        onConfirm={handleDeleteConfirm}
       />
     </div>
   )

--- a/src/components/organisms/authors/AuthorBlockDialog.tsx
+++ b/src/components/organisms/authors/AuthorBlockDialog.tsx
@@ -58,18 +58,22 @@ export const AuthorBlockDialog: React.FC<AuthorBlockDialogProps> = ({
         if (!loading) onOpenChange(next)
       }}
     >
-      <DialogContent className='max-w-md'>
+      <DialogContent
+        className='max-w-md'
+        // Block mode renders no description, so keep Radix from pointing at a missing node.
+        {...(isBlocking ? { 'aria-describedby': undefined } : {})}
+      >
         <DialogHeader>
           <DialogTitle>
             {isBlocking
               ? t('blockDialog.blockTitle')
               : t('blockDialog.unblockTitle')}
           </DialogTitle>
-          <DialogDescription>
-            {isBlocking
-              ? t('blockDialog.blockDescription', { name: fullName(author) })
-              : t('blockDialog.unblockDescription', { name: fullName(author) })}
-          </DialogDescription>
+          {!isBlocking && (
+            <DialogDescription>
+              {t('blockDialog.unblockDescription', { name: fullName(author) })}
+            </DialogDescription>
+          )}
         </DialogHeader>
 
         {isBlocking && (

--- a/src/components/organisms/premium/MembershipTable.tsx
+++ b/src/components/organisms/premium/MembershipTable.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Crown, Eye, Pencil, Trash2 } from 'lucide-react'
+import { Crown, Eye, Pencil } from 'lucide-react'
 import { Badge } from '@/components/atoms/badge'
 import { Button } from '@/components/atoms/button'
 import { DataTable, type Column } from '@/components/organisms/DataTable'
@@ -11,9 +11,8 @@ interface MembershipTableProps {
   loading: boolean
   onView: (id: string) => void
   onEdit: (id: string) => void
-  onDelete: (id: string) => void
   onToggleStatus: (id: string, currentStatus: string) => void
-  // When false, edit / delete actions and the status toggle are read-only.
+  // When false, the edit action and the status toggle are read-only.
   canWrite?: boolean
 }
 
@@ -22,7 +21,6 @@ export const MembershipTable: React.FC<MembershipTableProps> = ({
   loading,
   onView,
   onEdit,
-  onDelete,
   onToggleStatus,
   canWrite = true,
 }) => {
@@ -153,26 +151,15 @@ export const MembershipTable: React.FC<MembershipTableProps> = ({
             <Eye className='h-4 w-4' />
           </Button>
           {canWrite && (
-            <>
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
-                title={t('actions.edit')}
-                onClick={() => onEdit(row.id)}
-              >
-                <Pencil className='h-4 w-4' />
-              </Button>
-              <Button
-                variant='ghost'
-                size='sm'
-                className='h-8 w-8 p-0 text-muted-foreground hover:bg-destructive/10 hover:text-destructive'
-                title={t('actions.delete')}
-                onClick={() => onDelete(row.id)}
-              >
-                <Trash2 className='h-4 w-4' />
-              </Button>
-            </>
+            <Button
+              variant='ghost'
+              size='sm'
+              className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
+              title={t('actions.edit')}
+              onClick={() => onEdit(row.id)}
+            >
+              <Pencil className='h-4 w-4' />
+            </Button>
           )}
         </div>
       )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -2529,7 +2529,6 @@
     "blockDialog": {
       "blockTitle": "Block author from posting",
       "unblockTitle": "Unblock author",
-      "blockDescription": "{name} will no longer be able to create new listings. They will see a notice and be blocked on the backend.",
       "unblockDescription": "{name} will be able to post listings again.",
       "reasonLabel": "Reason (optional)",
       "reasonPlaceholder": "e.g. Multiple listings with approved violation reports"

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -2493,7 +2493,6 @@
     "blockDialog": {
       "blockTitle": "Chặn đăng tin",
       "unblockTitle": "Mở lại quyền đăng tin",
-      "blockDescription": "{name} sẽ không thể đăng tin mới. Người dùng sẽ thấy thông báo và bị chặn ở backend.",
       "unblockDescription": "{name} sẽ có thể đăng tin trở lại.",
       "reasonLabel": "Lý do (không bắt buộc)",
       "reasonPlaceholder": "vd: Nhiều tin đăng có report vi phạm đã được duyệt"


### PR DESCRIPTION
- Drop the delete button from the membership packages table and unwire the delete dialog, handler and state from the premium section page.
- Remove the description line from the author block confirmation dialog (unblock mode keeps its description).