### PR TITLE
feat(posts): show poster avatar in the content posts table

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -185,9 +185,11 @@ export interface ListingResponseWithAdmin {
 // Admin Listing List Item — slim summary returned by /v1/listings/admin/list
 // (full record is fetched via /v1/listings/admin/{id})
 export interface OwnerSummary {
+  userId?: string | null
   firstName: string | null
   lastName: string | null
   contactPhoneNumber: string | null
+  avatarUrl?: string | null
 }
 
 export interface AdminVerificationSummary {

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/components/organisms/DataTable'
 import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
-import { Avatar } from '@/components/atoms/avatar'
+import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
 import { MediaThumbnail } from '@/components/molecules/mediaPreview'
 import { Eye } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -135,13 +135,13 @@ export const PostTable: React.FC<PostTableProps> = ({
       sortable: true,
       render: (_, row) => (
         <div className='flex items-center justify-end gap-2 lg:justify-start'>
-          <Avatar className='h-10 w-10'>
-            <div className='h-full w-full bg-muted flex items-center justify-center text-foreground font-semibold'>
-              {row.poster.name.charAt(0).toUpperCase()}
-            </div>
-          </Avatar>
-          <div>
-            <div className='text-sm font-medium text-foreground'>
+          <InitialsAvatar
+            name={row.poster.name}
+            src={row.poster.avatar}
+            size='md'
+          />
+          <div className='min-w-0'>
+            <div className='truncate text-sm font-medium text-foreground'>
               {row.poster.name}
             </div>
             <div className='text-xs text-muted-foreground'>

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -397,8 +397,8 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
     vipType: item.vipType || undefined,
     poster: {
       name: fullName || 'Unknown User',
-      avatar: undefined,
-      userId: '',
+      avatar: item.user?.avatarUrl || undefined,
+      userId: item.user?.userId || '',
       phone: item.user?.contactPhoneNumber || '',
     },
     propertyInfo: {


### PR DESCRIPTION
The "Người đăng" column rendered a flat muted circle with a single letter because mapSummaryToUI hardcoded avatar: undefined. Consume the owner avatarUrl/userId now returned by /v1/listings/admin/list and reuse the shared InitialsAvatar (same as the authors/admins tables), which falls back to deterministic gradient initials when the user has no avatar or the image fails to load.