### PR TITLE
fix(deps): upgrade next to 15.4.10 to patch RSC DoS/source-exposure CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.17.21",
     "lucide-react": "^0.539.0",
     "motion": "^12.23.22",
-    "next": "15.4.8",
+    "next": "15.4.10",
     "next-intl": "^4.3.5",
     "next-themes": "^0.4.6",
     "react": "19.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -792,10 +792,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.4.8":
-  version: 15.4.8
-  resolution: "@next/env@npm:15.4.8"
-  checksum: 10c0/6b0555e30c175a04781a75f0ddc2630bea1af0f31bac0c7875d6063bec9fb2ee50ccf6a3965e532604f40a2c98f1ceb8eb52283b449ba4345ab1b50a0fde8b88
+"@next/env@npm:15.4.10":
+  version: 15.4.10
+  resolution: "@next/env@npm:15.4.10"
+  checksum: 10c0/f455f9630f56691800441333bf1462135f64eba65cc81a34fceedb42fcc62fd22fb2dfaa8de49f65b378fc46c5cf35795c0a32363006b989806223856be221fa
   languageName: node
   linkType: hard
 
@@ -6273,11 +6273,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.4.8":
-  version: 15.4.8
-  resolution: "next@npm:15.4.8"
+"next@npm:15.4.10":
+  version: 15.4.10
+  resolution: "next@npm:15.4.10"
   dependencies:
-    "@next/env": "npm:15.4.8"
+    "@next/env": "npm:15.4.10"
     "@next/swc-darwin-arm64": "npm:15.4.8"
     "@next/swc-darwin-x64": "npm:15.4.8"
     "@next/swc-linux-arm64-gnu": "npm:15.4.8"
@@ -6328,7 +6328,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/4bbeb66d2db81f7f8580b3db0e14569bf09d71b958a3c65ddfb23015f316f3b85a4bf32349c9d21b03a61cd31b7d4e19829ff625b71dbde6ab0aa8db60bacd90
+  checksum: 10c0/67101363146d48f6e532b7b4d15df6d6a02601782037e4f9013f620a3cb046231a0db986bd983e1726b95aa30d10d02f673f9f123188582fe7c42d1fe94d74d9
   languageName: node
   linkType: hard
 
@@ -7592,7 +7592,7 @@ __metadata:
     lodash: "npm:^4.17.21"
     lucide-react: "npm:^0.539.0"
     motion: "npm:^12.23.22"
-    next: "npm:15.4.8"
+    next: "npm:15.4.10"
     next-intl: "npm:^4.3.5"
     next-themes: "npm:^0.4.6"
     prettier: "npm:^3.6.2"


### PR DESCRIPTION
Next 15.4.8 is affected by CVE-2025-55184 (DoS) and CVE-2025-55183 (source code exposure); 15.4.10 is the patched release for the 15.4.x line. This also resolves the Vercel build failure on /_not-found ("TypeError: d.createContext is not a function"), which was traced to a stale build cache rather than a source bug — bumping the dependency forces a clean build/cache.