### PR TITLE
feat(posts): highlight AI-flagged invalid images in the review dialog

### DIFF
--- a/src/components/organisms/posts/PostAiAnalysis.tsx
+++ b/src/components/organisms/posts/PostAiAnalysis.tsx
@@ -12,6 +12,7 @@ import {
   Info,
   Files,
   History,
+  Eye,
 } from 'lucide-react'
 import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
@@ -31,6 +32,8 @@ import {
   getSuggestedStatusColor,
   getSeverityColor,
   toPercent,
+  parseInvalidImageIssues,
+  InvalidImageIssue,
 } from '@/utils/ai-verification.utils'
 import { AiServiceStatusBadge } from '@/components/molecules/aiServiceStatus/AiServiceStatusBadge'
 
@@ -38,6 +41,10 @@ interface PostAiAnalysisProps {
   post: UIPostData | null
   /** Reset internal state when the host modal closes/reopens. */
   open: boolean
+  /** Fires whenever the AI result (re)loads, with the images it flagged as invalid. */
+  onInvalidImagesChange?: (images: InvalidImageIssue[]) => void
+  /** Open the gallery lightbox on a specific (0-based) image index. */
+  onViewInvalidImage?: (index: number) => void
 }
 
 const ValidationCard: React.FC<{
@@ -50,6 +57,8 @@ const ValidationCard: React.FC<{
   stats?: { label: string; value: React.ReactNode }[]
   issues: string[]
   issuesLabel: string
+  /** Custom rendering for a single issue line (used to add the "view image" button). */
+  renderIssue?: (issue: string, index: number) => React.ReactNode
 }> = ({
   title,
   valid,
@@ -60,6 +69,7 @@ const ValidationCard: React.FC<{
   stats,
   issues,
   issuesLabel,
+  renderIssue,
 }) => (
   <div className='rounded-lg border border-border/70 p-3'>
     <div className='flex items-start justify-between gap-2'>
@@ -96,7 +106,7 @@ const ValidationCard: React.FC<{
         <ul className='mt-1 list-inside list-disc space-y-0.5 text-xs text-muted-foreground'>
           {issues.map((issue, i) => (
             <li key={i} className='break-words'>
-              {issue}
+              {renderIssue ? renderIssue(issue, i) : issue}
             </li>
           ))}
         </ul>
@@ -108,6 +118,8 @@ const ValidationCard: React.FC<{
 export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
   post,
   open,
+  onInvalidImagesChange,
+  onViewInvalidImage,
 }) => {
   const t = useTranslations('posts')
   const [loadingStore, setLoadingStore] = useState(false)
@@ -184,6 +196,15 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
       cancelled = true
     }
   }, [post, open])
+
+  // Let the host modal know which images the AI flagged as invalid (so it can
+  // highlight them in the gallery/lightbox) every time a fresh result loads.
+  useEffect(() => {
+    const invalidImages = result
+      ? parseInvalidImageIssues(result.image_validation.issues)
+      : []
+    onInvalidImagesChange?.(invalidImages)
+  }, [result, onInvalidImagesChange])
 
   const duplicateDecisionColor = (decision: AiDuplicateDecision) =>
     decision === 'DUPLICATE'
@@ -442,6 +463,26 @@ export const PostAiAnalysis: React.FC<PostAiAnalysisProps> = ({
                 ]}
                 issues={result.image_validation.issues}
                 issuesLabel={t('aiAnalysis.issues')}
+                renderIssue={(issue) => {
+                  const [parsed] = parseInvalidImageIssues([issue])
+                  if (!parsed)
+                    return <span className='break-words'>{issue}</span>
+                  return (
+                    <span className='flex items-start justify-between gap-2'>
+                      <span className='min-w-0 flex-1 break-words'>
+                        {issue}
+                      </span>
+                      <button
+                        type='button'
+                        onClick={() => onViewInvalidImage?.(parsed.index)}
+                        className='inline-flex shrink-0 items-center gap-1 rounded-md border border-destructive/40 bg-destructive/10 px-2 py-0.5 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/20'
+                      >
+                        <Eye className='h-3 w-3' />
+                        {t('aiAnalysis.viewImageButton')}
+                      </button>
+                    </span>
+                  )
+                }}
               />
               <ValidationCard
                 title={t('aiAnalysis.videoValidation')}

--- a/src/components/organisms/posts/PostReviewModal.tsx
+++ b/src/components/organisms/posts/PostReviewModal.tsx
@@ -35,6 +35,7 @@ import {
   Wifi,
   Receipt,
   Mail,
+  AlertTriangle,
   type LucideIcon,
 } from 'lucide-react'
 
@@ -42,6 +43,7 @@ const MAX_VISIBLE_THUMBS = 8
 import { cn } from '@/lib/utils'
 import { UIPostData } from '@/types/posts.type'
 import { getAmenityIcon, getStatusColor } from '@/utils/post.utils' // Need to ensure these helpers are exported correctly or pass translations
+import { InvalidImageIssue } from '@/utils/ai-verification.utils'
 import { PostAiAnalysis } from '@/components/organisms/posts/PostAiAnalysis'
 import { VipTypeBadge } from '@/components/organisms/posts/PostTable'
 import {
@@ -114,6 +116,10 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
   const [verificationNotes, setVerificationNotes] = useState('')
   const [lightboxOpen, setLightboxOpen] = useState(false)
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
+  // Images the AI verification flagged as invalid, reported by PostAiAnalysis
+  // (parsed from image_validation.issues) — used to highlight the gallery/
+  // lightbox and to jump straight to the offending image from the reason list.
+  const [invalidImages, setInvalidImages] = useState<InvalidImageIssue[]>([])
 
   // Reset state when modal opens/closes or post changes
   React.useEffect(() => {
@@ -383,12 +389,27 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
                   {visibleImages.map((img, idx) => {
                     const isLastVisible = idx === visibleImages.length - 1
                     const showMoreOverlay = isLastVisible && hiddenCount > 0
+                    const invalidIssue = invalidImages.find(
+                      (v) => v.index === idx,
+                    )
+                    // A hidden (beyond MAX_VISIBLE_THUMBS) image can still be
+                    // flagged — surface that on the "+N" overlay tile too, so
+                    // it isn't invisible just because it didn't make the grid.
+                    const hasHiddenInvalid =
+                      showMoreOverlay &&
+                      invalidImages.some((v) => v.index >= visibleImages.length)
                     return (
                       <button
                         type='button'
                         key={idx}
                         onClick={() => openLightbox(idx)}
-                        className='group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-lg border border-border bg-muted outline-none transition-shadow focus-visible:ring-4 focus-visible:ring-ring'
+                        title={invalidIssue?.reason}
+                        className={cn(
+                          'group relative aspect-[4/3] cursor-pointer overflow-hidden rounded-lg border bg-muted outline-none transition-shadow focus-visible:ring-4 focus-visible:ring-ring',
+                          invalidIssue || hasHiddenInvalid
+                            ? 'border-destructive ring-2 ring-destructive/50'
+                            : 'border-border',
+                        )}
                       >
                         <MediaThumbnail
                           src={img}
@@ -402,6 +423,11 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
                         ) : (
                           <div className='absolute inset-0 flex items-center justify-center bg-black/0 transition-colors group-hover:bg-black/35'>
                             <ZoomIn className='h-5 w-5 text-white opacity-0 transition-opacity group-hover:opacity-100' />
+                          </div>
+                        )}
+                        {(invalidIssue || hasHiddenInvalid) && (
+                          <div className='absolute left-1 top-1 flex items-center justify-center rounded-full bg-destructive p-1 text-white shadow-sm'>
+                            <AlertTriangle className='h-3 w-3' />
                           </div>
                         )}
                       </button>
@@ -620,7 +646,12 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
             {showAiSidebar && (
               <div className='space-y-5 px-6 py-5 lg:w-[440px] lg:shrink-0 lg:overflow-y-auto'>
                 {/* AI-assisted analysis (advisory only) */}
-                <PostAiAnalysis post={selectedPost} open={open} />
+                <PostAiAnalysis
+                  post={selectedPost}
+                  open={open}
+                  onInvalidImagesChange={setInvalidImages}
+                  onViewInvalidImage={openLightbox}
+                />
 
                 {/* Rejection Reason / Verification Notes — only while a moderation decision is pending */}
                 {isPending && (
@@ -786,6 +817,29 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
               alt={`${selectedPost.title} ${currentImageIndex + 1}`}
               className='object-contain'
             />
+
+            {/* AI-flagged reason for the image currently shown */}
+            {(() => {
+              const activeIssue = invalidImages.find(
+                (v) => v.index === currentImageIndex,
+              )
+              if (!activeIssue) return null
+              return (
+                <div className='absolute left-1/2 top-4 z-10 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2 rounded-lg border border-destructive/50 bg-destructive px-4 py-2.5 text-sm text-white shadow-lg'>
+                  <div className='flex items-start gap-2'>
+                    <AlertTriangle className='mt-0.5 h-4 w-4 shrink-0' />
+                    <div className='min-w-0'>
+                      <div className='font-semibold'>
+                        {t('aiAnalysis.invalidImageBadge')}
+                      </div>
+                      <div className='mt-0.5 break-words text-white/90'>
+                        {activeIssue.reason}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )
+            })()}
           </div>
 
           {selectedPost.images.length > 1 && (
@@ -810,24 +864,34 @@ export const PostReviewModal: React.FC<PostReviewModalProps> = ({
 
             {selectedPost.images.length > 1 && (
               <div className='flex max-w-full gap-2 overflow-x-auto pb-1'>
-                {selectedPost.images.map((img, idx) => (
-                  <button
-                    type='button'
-                    key={idx}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      setCurrentImageIndex(idx)
-                    }}
-                    className={cn(
-                      'relative h-14 w-20 shrink-0 overflow-hidden rounded-md border-2 transition-opacity',
-                      idx === currentImageIndex
-                        ? 'border-white opacity-100'
-                        : 'border-transparent opacity-50 hover:opacity-90',
-                    )}
-                  >
-                    <MediaThumbnail src={img} alt={`thumbnail ${idx + 1}`} />
-                  </button>
-                ))}
+                {selectedPost.images.map((img, idx) => {
+                  const isInvalid = invalidImages.some((v) => v.index === idx)
+                  return (
+                    <button
+                      type='button'
+                      key={idx}
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        setCurrentImageIndex(idx)
+                      }}
+                      className={cn(
+                        'relative h-14 w-20 shrink-0 overflow-hidden rounded-md border-2 transition-opacity',
+                        idx === currentImageIndex
+                          ? 'border-white opacity-100'
+                          : isInvalid
+                            ? 'border-destructive opacity-75 hover:opacity-100'
+                            : 'border-transparent opacity-50 hover:opacity-90',
+                      )}
+                    >
+                      <MediaThumbnail src={img} alt={`thumbnail ${idx + 1}`} />
+                      {isInvalid && (
+                        <div className='absolute right-0.5 top-0.5 flex items-center justify-center rounded-full bg-destructive p-0.5 text-white'>
+                          <AlertTriangle className='h-2.5 w-2.5' />
+                        </div>
+                      )}
+                    </button>
+                  )
+                })}
               </div>
             )}
           </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1879,6 +1879,8 @@
       "missingFields": "Missing",
       "violations": "Violations",
       "suggestions": "Suggestions",
+      "viewImageButton": "View image",
+      "invalidImageBadge": "AI flagged this image as invalid",
       "advisoryNote": "This AI assessment is advisory only — the moderation decision remains with you.",
       "suggested": {
         "APPROVED": "Approve",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1843,6 +1843,8 @@
       "missingFields": "Thiếu",
       "violations": "Vi phạm",
       "suggestions": "Gợi ý",
+      "viewImageButton": "Xem ảnh",
+      "invalidImageBadge": "AI phát hiện ảnh này không hợp lệ",
       "advisoryNote": "Đánh giá AI chỉ mang tính tham khảo — quyết định kiểm duyệt vẫn thuộc về bạn.",
       "suggested": {
         "APPROVED": "Duyệt",

--- a/src/utils/ai-verification.utils.ts
+++ b/src/utils/ai-verification.utils.ts
@@ -114,3 +114,30 @@ export const getSeverityColor = (level: AiSeverity | AiPriority): string => {
 /** Round a 0..1 score to a whole percentage for display. */
 export const toPercent = (value: number): number =>
   Math.round((Number.isFinite(value) ? value : 0) * 100)
+
+export interface InvalidImageIssue {
+  /** 0-based index into the listing's `images` array. */
+  index: number
+  reason: string
+}
+
+// The AI service (smartrent-ai/app/ai/llm/gemini_listing_helper.py) sends each
+// image to the model preceded by a literal "Ảnh N:" text label, where N is the
+// 1-based position in the same `images` array the FE submitted — and is
+// instructed to prefix any invalid-image issue with that exact label. That
+// convention is the only per-image link available in image_validation.issues
+// today, so we parse it back out to know which image to highlight/open.
+const IMAGE_ISSUE_PREFIX = /^Ảnh\s+(\d+)\s*:\s*(.*)$/
+
+/** Extract {index, reason} for issues that carry the "Ảnh N:" image label. */
+export const parseInvalidImageIssues = (
+  issues: string[],
+): InvalidImageIssue[] =>
+  issues.reduce<InvalidImageIssue[]>((acc, issue) => {
+    const match = issue.match(IMAGE_ISSUE_PREFIX)
+    if (!match) return acc
+    const oneBasedIndex = Number(match[1])
+    if (!Number.isFinite(oneBasedIndex) || oneBasedIndex < 1) return acc
+    acc.push({ index: oneBasedIndex - 1, reason: match[2].trim() || issue })
+    return acc
+  }, [])


### PR DESCRIPTION
Parses the "Ảnh N:" image label the AI service already prefixes onto image_validation issues to link each issue back to its image, then:
- highlights that thumbnail (and the lightbox/thumbnail strip) in red
- adds a "view image" button next to the issue in the AI Analysis panel that jumps straight to the image and shows the reason as an overlay