### PR TITLE
feat(posts): quick-approve AI-approved posts from the table row

### DIFF
--- a/src/api/types/listing.type.ts
+++ b/src/api/types/listing.type.ts
@@ -209,6 +209,20 @@ export type SummaryListingStatus =
   | 'VERIFIED'
   | 'RESUBMITTED'
 
+/**
+ * Present only when the AI background moderation job already suggests this
+ * listing is safe to approve and no admin has acted on it yet — drives the
+ * admin table's quick-approve affordance. Absent for every other state (still
+ * pending, AI flagged it, or an admin already reviewed it).
+ */
+export interface AdminListingAiModerationSummary {
+  /** AI confidence score, 0-1. */
+  score: number | null
+  /** Short human-readable reason the AI gave for its suggestion. */
+  reason: string | null
+  analyzedAt: string | null
+}
+
 export interface AdminListingSummary {
   listingId: number
   title: string
@@ -232,6 +246,7 @@ export interface AdminListingSummary {
   revisionCount: number | null
   lastModerationReasonCode: string | null
   lastModerationReasonText: string | null
+  aiModeration?: AdminListingAiModerationSummary | null
 }
 
 // Statistics for Admin Dashboard

--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -17,12 +17,15 @@ import { PostStats } from '@/components/molecules/posts/PostStats'
 import { PostTable } from '@/components/organisms/posts/PostTable'
 import { PostReviewModal } from '@/components/organisms/posts/PostReviewModal'
 import { AiAutoVerifyControl } from '@/components/molecules/aiServiceStatus/AiAutoVerifyControl'
+import { ConfirmDialog } from '@/components/molecules/confirmDialog'
+import { toPercent } from '@/utils/ai-verification.utils'
 
 // Backend success envelope code (see constants/env API_RESPONSE_CODES.SUCCESS).
 const SUCCESS_CODE = '999999'
 
 const PostVerification = () => {
   const t = useTranslations('posts')
+  const tCommon = useTranslations('common')
   const [posts, setPosts] = useState<UIPostData[]>([])
   const [initialLoading, setInitialLoading] = useState(true)
   const [tableLoading, setTableLoading] = useState(false)
@@ -31,6 +34,9 @@ const PostVerification = () => {
   const [detailLoading, setDetailLoading] = useState(false)
   const [actionLoading, setActionLoading] = useState(false)
   const [visibilityLoading, setVisibilityLoading] = useState(false)
+  const [quickApproveTarget, setQuickApproveTarget] =
+    useState<UIPostData | null>(null)
+  const [quickApproveLoading, setQuickApproveLoading] = useState(false)
   const [stats, setStats] = useState<ListingStatisticsSummary>({
     pendingVerification: 0,
     verified: 0,
@@ -163,6 +169,35 @@ const PostVerification = () => {
       toast.error(t('toasts.approveError'))
     } finally {
       setActionLoading(false)
+    }
+  }
+
+  // Quick-approve straight from the table row for posts the AI background job
+  // already suggested approving — reuses the same approve endpoint as the
+  // review dialog, just without needing to fetch the full listing detail first.
+  const handleQuickApprove = (post: UIPostData) => setQuickApproveTarget(post)
+
+  const confirmQuickApprove = async () => {
+    if (!quickApproveTarget) return
+
+    try {
+      setQuickApproveLoading(true)
+      const response = await ListingService.approveListing(
+        quickApproveTarget.id,
+      )
+
+      if (response.success && response.code === SUCCESS_CODE) {
+        toast.success(t('toasts.approveSuccess'))
+        setQuickApproveTarget(null)
+        await fetchListings()
+      } else {
+        toast.error(response.message || t('toasts.approveError'))
+      }
+    } catch (error) {
+      console.error('Error quick-approving listing:', error)
+      toast.error(t('toasts.approveError'))
+    } finally {
+      setQuickApproveLoading(false)
     }
   }
 
@@ -306,9 +341,41 @@ const PostVerification = () => {
             filterValues={filterValues}
             onFilterChange={handleFilterChange}
             onReview={handleReview}
+            onQuickApprove={handleQuickApprove}
           />
         </div>
       )}
+
+      <ConfirmDialog
+        open={!!quickApproveTarget}
+        onOpenChange={(open) => !open && setQuickApproveTarget(null)}
+        title={t('table.quickApproveTitle')}
+        description={
+          quickApproveTarget && (
+            <div className='space-y-2'>
+              <p>
+                {t('table.quickApproveDescription', {
+                  title: quickApproveTarget.title,
+                })}
+              </p>
+              <div className='rounded-lg border border-success/30 bg-success/10 p-2.5 text-xs text-foreground/80 dark:bg-success/20'>
+                {quickApproveTarget.aiQuickApprove?.reason ||
+                  t('table.aiApprovedBadge')}
+                {typeof quickApproveTarget.aiQuickApprove?.score ===
+                  'number' && (
+                  <span className='ml-1 font-medium text-success-foreground'>
+                    ({toPercent(quickApproveTarget.aiQuickApprove.score)}%)
+                  </span>
+                )}
+              </div>
+            </div>
+          )
+        }
+        confirmLabel={t('table.quickApproveConfirm')}
+        cancelLabel={tCommon('cancel')}
+        onConfirm={confirmQuickApprove}
+        loading={quickApproveLoading}
+      />
 
       <PostReviewModal
         open={reviewModalOpen}

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
 import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
 import { MediaThumbnail } from '@/components/molecules/mediaPreview'
-import { Eye } from 'lucide-react'
+import { Eye, Sparkles, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PostStatus, UIPostData } from '@/types/posts.type'
 import { getPropertyIcon, getStatusColor } from '@/utils/post.utils'
@@ -45,6 +45,7 @@ interface PostTableProps {
   filterValues: Record<string, unknown>
   onFilterChange: (filters: Record<string, unknown>) => void
   onReview: (post: UIPostData) => void
+  onQuickApprove: (post: UIPostData) => void
 }
 
 export const PostTable: React.FC<PostTableProps> = ({
@@ -54,6 +55,7 @@ export const PostTable: React.FC<PostTableProps> = ({
   filterValues,
   onFilterChange,
   onReview,
+  onQuickApprove,
 }) => {
   const t = useTranslations('posts')
 
@@ -349,19 +351,46 @@ export const PostTable: React.FC<PostTableProps> = ({
       defaultSort={{ key: 'postedDate', direction: 'desc' }}
       emptyMessage={t('table.noPostsFound')}
       getRowKey={(row) => row.id}
-      actions={(row) => (
-        <div className='flex items-center justify-center gap-0.5'>
-          <Button
-            variant='ghost'
-            size='sm'
-            onClick={() => onReview(row)}
-            className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
-            title={t('table.reviewButton')}
-          >
-            <Eye className='h-4 w-4' />
-          </Button>
-        </div>
-      )}
+      actions={(row) => {
+        const aiQuickApprove = row.aiQuickApprove
+        return (
+          <div className='flex flex-col items-center gap-1'>
+            <div className='flex items-center justify-center gap-0.5'>
+              {aiQuickApprove && (
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  onClick={() => onQuickApprove(row)}
+                  className='h-8 w-8 p-0 text-success hover:bg-success/10 hover:text-success dark:text-success-foreground'
+                  title={t('table.quickApproveButton')}
+                >
+                  <CheckCircle2 className='h-4 w-4' />
+                </Button>
+              )}
+              <Button
+                variant='ghost'
+                size='sm'
+                onClick={() => onReview(row)}
+                className='h-8 w-8 p-0 text-muted-foreground hover:text-foreground'
+                title={t('table.reviewButton')}
+              >
+                <Eye className='h-4 w-4' />
+              </Button>
+            </div>
+            {aiQuickApprove && (
+              <div
+                className='flex max-w-25 items-center gap-1 rounded-full border border-success/30 bg-success/10 px-1.5 py-0.5 dark:bg-success/20'
+                title={aiQuickApprove.reason || t('table.aiApprovedBadge')}
+              >
+                <Sparkles className='h-3 w-3 shrink-0 text-success' />
+                <span className='truncate text-[10px] font-medium text-success-foreground'>
+                  {aiQuickApprove.reason || t('table.aiApprovedBadge')}
+                </span>
+              </div>
+            )}
+          </div>
+        )
+      }}
     />
   )
 }

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1767,7 +1767,12 @@
       "viewDetails": "View Details",
       "posts": "posts",
       "month": "month",
-      "reviewButton": "Review"
+      "reviewButton": "Review",
+      "quickApproveButton": "Quick approve (AI already approved in the background)",
+      "aiApprovedBadge": "AI approved",
+      "quickApproveTitle": "Quick approve listing",
+      "quickApproveDescription": "The background AI job already reviewed and suggested approving \"{title}\". Approve it now?",
+      "quickApproveConfirm": "Approve now"
     },
     "review": {
       "title": "Review Post",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1731,7 +1731,12 @@
       "viewDetails": "Xem Chi Tiết",
       "posts": "bài đăng",
       "month": "tháng",
-      "reviewButton": "Xem Xét"
+      "reviewButton": "Xem Xét",
+      "quickApproveButton": "Duyệt nhanh (AI đã duyệt nền)",
+      "aiApprovedBadge": "AI đã duyệt",
+      "quickApproveTitle": "Duyệt nhanh tin đăng",
+      "quickApproveDescription": "AI đã kiểm duyệt nền và đề xuất duyệt tin \"{title}\". Bạn có muốn duyệt ngay không?",
+      "quickApproveConfirm": "Duyệt ngay"
     },
     "review": {
       "title": "Xem Xét Bài Đăng",

--- a/src/types/posts.type.ts
+++ b/src/types/posts.type.ts
@@ -12,6 +12,15 @@ export type PostStatus =
   | 'expired'
   | 'pending_payment'
 
+/** Present only when the AI background job already suggests approving this
+ * post and no admin has reviewed it yet — drives the table's quick-approve
+ * affordance. */
+export type AiQuickApprove = {
+  score: number | null
+  reason: string | null
+  analyzedAt: string | null
+}
+
 export type UIPostData = {
   id: string
   title: string
@@ -54,4 +63,5 @@ export type UIPostData = {
   electricityPrice?: string | null
   internetPrice?: string | null
   serviceFee?: string | null
+  aiQuickApprove?: AiQuickApprove | null
 }

--- a/src/utils/post.utils.tsx
+++ b/src/utils/post.utils.tsx
@@ -422,6 +422,13 @@ export const mapSummaryToUI = (item: AdminListingSummary): UIPostData => {
     isVerify: false,
     rejectionReason: item.lastModerationReasonText || undefined,
     verificationNotes: undefined,
+    aiQuickApprove: item.aiModeration
+      ? {
+          score: item.aiModeration.score,
+          reason: item.aiModeration.reason,
+          analyzedAt: item.aiModeration.analyzedAt,
+        }
+      : null,
   }
 }
 


### PR DESCRIPTION
The admin listing table only surfaced AI moderation results inside the review dialog, so quickly clearing posts the background AI job already vetted still meant opening every row. Show a quick-approve button plus an "AI approved" badge with the AI's short reason directly in the actions column whenever the backend flags a post as AI quick-approve eligible, and confirm-then-approve without needing to open the full review dialog first.