### PR TITLE
refactor(posts): simplify AI quick-approve row hint, polish confirm d…

### DIFF
--- a/src/components/features/posts/posts-page.tsx
+++ b/src/components/features/posts/posts-page.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner'
 import { useTranslations } from 'next-intl'
 import { ListingService } from '@/api/services/listing.service'
 import { ListingStatisticsSummary } from '@/api/types/listing.type'
-import { Loader2 } from 'lucide-react'
+import { Loader2, Sparkles } from 'lucide-react'
 import { UIPostData } from '@/types/posts.type'
 import {
   mapSummaryToUI,
@@ -18,7 +18,8 @@ import { PostTable } from '@/components/organisms/posts/PostTable'
 import { PostReviewModal } from '@/components/organisms/posts/PostReviewModal'
 import { AiAutoVerifyControl } from '@/components/molecules/aiServiceStatus/AiAutoVerifyControl'
 import { ConfirmDialog } from '@/components/molecules/confirmDialog'
-import { toPercent } from '@/utils/ai-verification.utils'
+import { toPercent, getScoreColorClasses } from '@/utils/ai-verification.utils'
+import { cn } from '@/lib/utils'
 
 // Backend success envelope code (see constants/env API_RESPONSE_CODES.SUCCESS).
 const SUCCESS_CODE = '999999'
@@ -352,21 +353,41 @@ const PostVerification = () => {
         title={t('table.quickApproveTitle')}
         description={
           quickApproveTarget && (
-            <div className='space-y-2'>
-              <p>
-                {t('table.quickApproveDescription', {
+            <div className='space-y-3 text-left'>
+              <p className='text-sm text-foreground/90'>
+                {t.rich('table.quickApproveDescription', {
                   title: quickApproveTarget.title,
+                  b: (chunks) => (
+                    <span className='font-semibold text-foreground'>
+                      {chunks}
+                    </span>
+                  ),
                 })}
               </p>
-              <div className='rounded-lg border border-success/30 bg-success/10 p-2.5 text-xs text-foreground/80 dark:bg-success/20'>
-                {quickApproveTarget.aiQuickApprove?.reason ||
-                  t('table.aiApprovedBadge')}
-                {typeof quickApproveTarget.aiQuickApprove?.score ===
-                  'number' && (
-                  <span className='ml-1 font-medium text-success-foreground'>
-                    ({toPercent(quickApproveTarget.aiQuickApprove.score)}%)
-                  </span>
+              <div
+                className={cn(
+                  'rounded-lg border p-3',
+                  getScoreColorClasses(
+                    quickApproveTarget.aiQuickApprove?.score ?? 1,
+                  ),
                 )}
+              >
+                <div className='flex items-center justify-between gap-2'>
+                  <span className='flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide opacity-80'>
+                    <Sparkles className='h-3.5 w-3.5' />
+                    {t('table.aiSuggestionLabel')}
+                  </span>
+                  {typeof quickApproveTarget.aiQuickApprove?.score ===
+                    'number' && (
+                    <span className='text-sm font-bold tabular-nums'>
+                      {toPercent(quickApproveTarget.aiQuickApprove.score)}%
+                    </span>
+                  )}
+                </div>
+                <p className='mt-2 text-sm leading-snug'>
+                  {quickApproveTarget.aiQuickApprove?.reason ||
+                    t('table.aiApprovedBadge')}
+                </p>
               </div>
             </div>
           )

--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -378,15 +378,10 @@ export const PostTable: React.FC<PostTableProps> = ({
               </Button>
             </div>
             {aiQuickApprove && (
-              <div
-                className='flex max-w-25 items-center gap-1 rounded-full border border-success/30 bg-success/10 px-1.5 py-0.5 dark:bg-success/20'
-                title={aiQuickApprove.reason || t('table.aiApprovedBadge')}
-              >
-                <Sparkles className='h-3 w-3 shrink-0 text-success' />
-                <span className='truncate text-[10px] font-medium text-success-foreground'>
-                  {aiQuickApprove.reason || t('table.aiApprovedBadge')}
-                </span>
-              </div>
+              <span className='flex items-center gap-1 text-[10px] font-medium text-success dark:text-success-foreground'>
+                <Sparkles className='h-3 w-3 shrink-0' />
+                {t('table.aiQuickApproveHint')}
+              </span>
             )}
           </div>
         )

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1769,9 +1769,11 @@
       "month": "month",
       "reviewButton": "Review",
       "quickApproveButton": "Quick approve (AI already approved in the background)",
+      "aiQuickApproveHint": "Eligible for AI quick approve",
       "aiApprovedBadge": "AI approved",
+      "aiSuggestionLabel": "AI suggestion",
       "quickApproveTitle": "Quick approve listing",
-      "quickApproveDescription": "The background AI job already reviewed and suggested approving \"{title}\". Approve it now?",
+      "quickApproveDescription": "The background AI job already reviewed and suggested approving <b>{title}</b>. Approve it now?",
       "quickApproveConfirm": "Approve now"
     },
     "review": {

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1733,9 +1733,11 @@
       "month": "tháng",
       "reviewButton": "Xem Xét",
       "quickApproveButton": "Duyệt nhanh (AI đã duyệt nền)",
+      "aiQuickApproveHint": "Có thể duyệt nhanh bằng AI",
       "aiApprovedBadge": "AI đã duyệt",
+      "aiSuggestionLabel": "Gợi ý từ AI",
       "quickApproveTitle": "Duyệt nhanh tin đăng",
-      "quickApproveDescription": "AI đã kiểm duyệt nền và đề xuất duyệt tin \"{title}\". Bạn có muốn duyệt ngay không?",
+      "quickApproveDescription": "AI đã kiểm duyệt nền và đề xuất duyệt tin <b>{title}</b>. Bạn có muốn duyệt ngay không?",
       "quickApproveConfirm": "Duyệt ngay"
     },
     "review": {


### PR DESCRIPTION
…ialog

The reason pill under the quick-approve button was cramped in the 120px-wide actions column and duplicated what the confirm dialog already shows. Replace it with a plain "eligible for AI quick approve" hint, and move the actual AI reason + score into a richer, score-band colored card inside the confirm dialog (mirrors the review dialog's AI panel styling) instead of a plain text line.