### PR TITLE
fix(posts): drop AI wording and icon from the quick-approve row hint

### DIFF
--- a/src/components/organisms/posts/PostTable.tsx
+++ b/src/components/organisms/posts/PostTable.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/atoms/button'
 import { Badge } from '@/components/atoms/badge'
 import { InitialsAvatar } from '@/components/molecules/initialsAvatar'
 import { MediaThumbnail } from '@/components/molecules/mediaPreview'
-import { Eye, Sparkles, CheckCircle2 } from 'lucide-react'
+import { Eye, CheckCircle2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PostStatus, UIPostData } from '@/types/posts.type'
 import { getPropertyIcon, getStatusColor } from '@/utils/post.utils'
@@ -378,8 +378,7 @@ export const PostTable: React.FC<PostTableProps> = ({
               </Button>
             </div>
             {aiQuickApprove && (
-              <span className='flex items-center gap-1 text-[10px] font-medium text-success dark:text-success-foreground'>
-                <Sparkles className='h-3 w-3 shrink-0' />
+              <span className='text-[10px] font-medium text-success dark:text-success-foreground'>
                 {t('table.aiQuickApproveHint')}
               </span>
             )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1769,7 +1769,7 @@
       "month": "month",
       "reviewButton": "Review",
       "quickApproveButton": "Quick approve (AI already approved in the background)",
-      "aiQuickApproveHint": "Eligible for AI quick approve",
+      "aiQuickApproveHint": "Eligible for quick approve",
       "aiApprovedBadge": "AI approved",
       "aiSuggestionLabel": "AI suggestion",
       "quickApproveTitle": "Quick approve listing",

--- a/src/messages/vi.json
+++ b/src/messages/vi.json
@@ -1733,7 +1733,7 @@
       "month": "tháng",
       "reviewButton": "Xem Xét",
       "quickApproveButton": "Duyệt nhanh (AI đã duyệt nền)",
-      "aiQuickApproveHint": "Có thể duyệt nhanh bằng AI",
+      "aiQuickApproveHint": "Có thể duyệt nhanh",
       "aiApprovedBadge": "AI đã duyệt",
       "aiSuggestionLabel": "Gợi ý từ AI",
       "quickApproveTitle": "Duyệt nhanh tin đăng",


### PR DESCRIPTION
Keep it a plain "eligible for quick approve" hint text — the AI attribution and score/reason already live in the confirm dialog.